### PR TITLE
Add a plugin for deriving NBT serializations.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+
+name = "hematite-nbt-macros"
+version = "0.0.1"
+authors = [ "Aaron Jacobs <atheriel@gmail.com>" ]
+
+[lib]
+name = "nbt_macros"
+path = "lib.rs"
+plugin = true
+
+[[test]]
+name = "all"
+path = "tests.rs"
+
+[dependencies.nbt]
+path = ".."

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,5 +13,12 @@ plugin = true
 name = "all"
 path = "tests.rs"
 
+[[test]]
+name = "compiletests"
+path = "tests/compiletest.rs"
+
 [dependencies.nbt]
 path = ".."
+
+[dev-dependencies]
+compiletest_rs = "*"

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -42,7 +42,7 @@
 //! Which will work so long as the fields of the struct have `NbtFmt`
 //! implementations of their own.
 
-#![feature(plugin_registrar, quote, rustc_private)]
+#![feature(plugin_registrar, rustc_private)]
 
 extern crate rustc;
 extern crate syntax;
@@ -53,7 +53,7 @@ use syntax::ext::base::{Annotatable, ExtCtxt, MultiDecorator};
 use syntax::ext::build::AstBuilder;
 use syntax::ext::deriving::generic::*;
 use syntax::ext::deriving::generic::ty::*;
-use syntax::parse::token::{get_ident, InternedString};
+use syntax::parse::token::{get_ident, intern_and_get_ident, InternedString};
 use syntax::ptr::P;
 
 
@@ -84,6 +84,7 @@ macro_rules! pathexpr {
     )
 }
 
+/// Expands uses of `#[derive(NbtFmt)]` into `NbtFmt` implementations.
 pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
                             item: &Annotatable,
                             push: &mut FnMut(Annotatable))
@@ -117,7 +118,7 @@ pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
                              pathvec!(nbt::NbtError),
                              None, Vec::new(), true)))),
                     true)),
-                attributes: Vec::new(),
+                attributes: Vec::new(), // FIXME: Benchmark adding #[inline].
                 is_unsafe: false,
                 combine_substructure: combine_substructure(Box::new(|c, s, sub| {
                     cs_nbtfmt(c, s, sub)
@@ -141,19 +142,23 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
         _ => cx.span_bug(trait_span,
                          "incorrect number of arguments in `derive(NbtFmt)`")
     };
-    
-    let call_nbt_fmt = |span, thing_expr, name| {
+
+    // Define a closure that iterates over the fields in the struct and
+    // generates a statement akin to `try!(NbtFmt::to_nbt(self, field));`.
+    let call_nbt_fmt = |span, struct_self, name| {
+
+        // Create expressions for the path to the `to_nbt` method and `&self`.
         let nbt_fmt_path = pathexpr!(cx, span, nbt::serialize::NbtFmt::to_nbt);
-        let ref_thing = cx.expr_addr_of(span, thing_expr);
-        
+        let self_arg = cx.expr_addr_of(span, struct_self);
+
         // Create a string literal expression for the field's identifier.
-        let name_lit = get_ident(name);
-        let name_expr = cx.expr_str(span, name_lit);
-        
+        //let name_lit = get_ident(name);
+        let name_expr = cx.expr_str(span, name);
+
         // Create a call expression, using the function path (nbt_fmt_path)
         // and `&self, dst, "<field>"` as arguments.
         let fmt_call = cx.expr_call(span, nbt_fmt_path,
-                                    vec!(ref_thing, dst_expr.clone(), name_expr));
+                                    vec!(self_arg, dst_expr.clone(), name_expr));
 
         // Wrap the call in a try! macro.
         let try_fmt_call = cx.expr_try(span, fmt_call);
@@ -161,47 +166,65 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
         // Add a semicolon.
         cx.stmt_expr(try_fmt_call)
     };
-    
+
     match *substr.fields {
         Struct(ref fields) => {   
             // Unit structs are kind of irrelevant for NBT, so throw an error
             // if someone tries to derive(NbtFmt) over one.
             if fields.is_empty() {
-                cx.span_err(trait_span,
-                            "`NbtFmt` has no meaning for unit structs.");
-                cx.expr_fail(trait_span, InternedString::new(""))
-            } else if fields[0].name.is_none() {
-                // FIXME: Handle tuple structs using to_nbt with each name as
-                //  "field0", etc.
-                cx.span_err(trait_span,
-                            "`NbtFmt` cannot yet be derived for tuple structs.");
-                cx.expr_fail(trait_span, InternedString::new(""))
-            } else {
-                let mut stmts = Vec::new();
-
-                for &FieldInfo { ref self_, span, name, .. } in fields {
-                    // FIXME: Use cx.bug for properly handling unnamed fields.
-                    stmts.push(call_nbt_fmt(span, self_.clone(), name.unwrap().clone()));
-                }
-
-                let close_nbt_path = pathexpr!(cx, trait_span, nbt::serialize::close_nbt);
-
-                let close = cx.expr_call(trait_span, close_nbt_path, vec![dst_expr.clone()]);
-                
-                cx.expr_block(cx.block(trait_span, stmts, Some(close)))
+                cx.span_err(trait_span, "`NbtFmt` has no meaning for unit structs.");
+                return cx.expr_fail(trait_span, InternedString::new(""));
             }
+
+            let mut stmts = Vec::with_capacity(fields.len());
+
+            // Handle tuple structs, i.e. `struct Test(i8, i8, String);`
+            // by using `"field0"`, `"field1"`, etc. as names.
+            if fields[0].name.is_none() {
+                for (i, field) in fields.iter().enumerate() {
+                    // Just in case there is a compiler bug and we get an
+                    // *named* field in the middle of a tuple struct, call `cx.bug`.
+                    if let Some(_) = field.name {
+                        cx.span_bug(trait_span, "named field in tuple struct")
+                    }
+
+                    // Make an interned "fieldX" string.
+                    let name_ = intern_and_get_ident(&format!("field{}", i));
+
+                    // Apply the closure on this named field.
+                    stmts.push(call_nbt_fmt(field.span, field.self_.clone(), name_));
+                }
+            } else {
+                for &FieldInfo { ref self_, span, name, .. } in fields {
+                    // Just in case there is a compiler bug and we get an
+                    // unnamed field in the middle of a struct, call `cx.bug`.
+                    if let None = name {
+                        cx.span_bug(trait_span, "unnamed field in named struct")
+                    }
+
+                    let name_ = get_ident(name.unwrap());
+
+                    // Apply the closure on this named field.
+                    stmts.push(call_nbt_fmt(span, self_.clone(), name_));
+                }
+            }
+
+            // Creates a `close_nbt(dst)` expression to add to the end of
+            // the block.
+            let close_nbt_path = pathexpr!(cx, trait_span, nbt::serialize::close_nbt);
+            let close = cx.expr_call(trait_span, close_nbt_path, vec![dst_expr.clone()]);
+
+            cx.expr_block(cx.block(trait_span, stmts, Some(close)))
         },
         EnumMatching(..) => {
-            cx.span_err(trait_span,
-                        "`NbtFmt` cannot yet be derived for enums.");
+            cx.span_err(trait_span, "`NbtFmt` cannot yet be derived for enums.");
             cx.expr_fail(trait_span, InternedString::new(""))
         },
         EnumNonMatchingCollapsed(..) => {
-            cx.span_bug(trait_span,
-                        "non-matching enum variants in `#[derive(NbtFmt)]`")
+            cx.span_bug(trait_span, "non-matching enum variants in `#[derive(NbtFmt)]`")
         },
         StaticEnum(..) | StaticStruct(..) => {
-            cx.span_bug(trait_span, "static method in `#[derive(NbtFmt)]`")
+            cx.span_bug(trait_span, "unexpected static method in `NbtFmt::to_bare_nbt`")
         },
     }
 }

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -1,0 +1,207 @@
+//! This crate contains a compiler plugin to generate NBT binary format
+//! serialization code for custom structs. It can be used as follows:
+//!
+//! ```ignore
+//! #![feature(plugin, custom_derive)]
+//! #![plugin(nbt_macros)]
+//! 
+//! extern crate nbt;
+//! 
+//! use nbt::NbtError;
+//! use nbt::serialize::{NbtFmt, to_writer};
+//! 
+//! #[derive(NbtFmt)]
+//! struct MyMob {
+//! 	name: String,
+//! 	health: i8
+//! }
+//!
+//! fn main() {
+//!     let mut bytes = Vec::new();
+//!     let mob = MyMob { name: "Dr. Evil".to_string(), health: 240 };
+//!
+//!     to_writer(&mut bytes, mob).unwrap();
+//! }
+//! ```
+//! 
+//! The custom `derive(NbtFmt)` will generate code equivalent to the following:
+//! 
+//! ```ignore
+//! impl NbtFmt for MyMob {
+//! 	fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//! 	   where W: std::io::Write
+//! 	{
+//! 		try!(self.name.write_nbt_fmt_with_name(dst, "name"));
+//!         try!(self.health.write_nbt_fmt_with_name(dst, "health"));
+//! 
+//!         close_nbt(dst)
+//! 	}
+//! }
+//! ```
+//! 
+//! Which will work so long as the fields of the struct have `NbtFmt`
+//! implementations of their own.
+
+#![feature(plugin_registrar, quote, rustc_private)]
+
+extern crate rustc;
+extern crate syntax;
+
+use syntax::ast::{Expr, MetaItem, Mutability};
+use syntax::codemap::Span;
+use syntax::ext::base::{Annotatable, ExtCtxt, MultiDecorator};
+use syntax::ext::build::AstBuilder;
+use syntax::ext::deriving::generic::*;
+use syntax::ext::deriving::generic::ty::*;
+use syntax::parse::token::{get_ident, InternedString};
+use syntax::ptr::P;
+
+
+#[plugin_registrar]
+#[doc(hidden)]
+pub fn plugin_registrar(reg: &mut rustc::plugin::Registry) {
+    reg.register_syntax_extension(
+        syntax::parse::token::intern("derive_NbtFmt"),
+        MultiDecorator(Box::new(expand_derive_nbtfmt)));
+}
+
+macro_rules! pathvec {
+    ($($x:ident)::+) => (
+        vec![ $( stringify!($x) ),+ ]
+    )
+}
+
+macro_rules! path {
+    ($($x:tt)*) => (
+        Path::new( pathvec!( $($x)* ) )
+    )
+}
+
+macro_rules! pathexpr {
+	($cx:ident, $span:ident, $($x:ident)::+) => (
+		$cx.expr_path($cx.path_global($span,
+			vec![ $( $cx.ident_of( stringify!($x) ) ),+ ]))
+	)
+}
+
+pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
+                            item: &Annotatable,
+                            push: &mut FnMut(Annotatable))
+{
+	let w_arg = Path::new_local("__W");
+    let trait_def = TraitDef {
+        span: span,
+        attributes: Vec::new(),
+        path: path!(nbt::serialize::NbtFmt),
+        additional_bounds: Vec::new(),
+        generics: LifetimeBounds::empty(),
+        methods: vec!(
+            MethodDef {
+                name: "write_nbt_fmt",
+                generics: LifetimeBounds {
+                    lifetimes: Vec::new(),
+                    // This adds a <__W: std::io::Writer> generic to the method.
+                    bounds: vec![("__W", vec![path!(std::io::Write)])],
+                },
+                // Pass the immutable borrowed self argument, `&self`.
+                explicit_self: borrowed_explicit_self(),
+                // Pass a single argument of type `&mut __W`.
+                args: vec!(Ptr(Box::new(Literal(w_arg)),
+                               Borrowed(None, Mutability::MutMutable))),
+                // Return a `Result<(), nbt::NbtError>`.
+                ret_ty: Literal(Path::new_(
+                    pathvec!(std::result::Result),
+                    None,
+                    vec!(Box::new(Tuple(Vec::new())), // Unit.
+                         Box::new(Literal(Path::new_( // nbt::NbtError
+                             pathvec!(nbt::NbtError),
+                             None, Vec::new(), true)))),
+                    true)),
+                attributes: Vec::new(),
+                is_unsafe: false,
+                combine_substructure: combine_substructure(Box::new(|c, s, sub| {
+                    cs_nbtfmt(c, s, sub)
+                })),
+            }
+        ),
+        associated_types: Vec::new(),
+    };
+
+    trait_def.expand(cx, meta_item, item, push)
+}
+
+fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
+    // Retrieve the argument passed to the write_nbt_fmt function, i.e. the
+    // `dst: &mut __W` bit. Since the method is already defined, there's no
+    // reason for this to fail, so we call `cx.span_bug` indicating a compiler
+    // error.
+    let dst_expr = match (substr.nonself_args.len(),
+                          substr.nonself_args.get(0)) {
+        (1, Some(dst)) => dst,
+        _ => cx.span_bug(trait_span,
+                         "incorrect number of arguments in `derive(NbtFmt)`")
+    };
+    
+    let call_nbt_fmt = |span, thing_expr, name| {
+        let nbt_fmt_path = pathexpr!(cx, span, nbt::serialize::NbtFmt::write_nbt_fmt_with_name);
+        let ref_thing = cx.expr_addr_of(span, thing_expr);
+        
+        // Create a string literal expression for the field's identifier.
+        let name_lit = get_ident(name);
+        let name_expr = cx.expr_str(span, name_lit);
+        
+        // Create a call expression, using the function path (nbt_fmt_path)
+        // and `&self, dst, "<field>"` as arguments.
+        let fmt_call = cx.expr_call(span, nbt_fmt_path,
+                                    vec!(ref_thing, dst_expr.clone(), name_expr));
+
+        // Wrap the call in a try! macro.
+        let try_fmt_call = cx.expr_try(span, fmt_call);
+
+        // Add a semicolon.
+        cx.stmt_expr(try_fmt_call)
+    };
+    
+    match *substr.fields {
+        Struct(ref fields) => {   
+        	// Unit structs are kind of irrelevant for NBT, so throw an error
+        	// if someone tries to derive(NbtFmt) over one.         
+            if fields.is_empty() {
+                cx.span_err(trait_span,
+                            "`NbtFmt` has no meaning for unit structs.");
+                cx.expr_fail(trait_span, InternedString::new(""))
+            } else if fields[0].name.is_none() {
+            	// FIXME: Handle tuple structs using write_nbt_fmt_with_name
+            	// with name = "".
+                cx.span_err(trait_span,
+                            "`NbtFmt` cannot yet be derived for tuple structs.");
+                cx.expr_fail(trait_span, InternedString::new(""))
+            } else {
+                let mut stmts = Vec::new();
+
+                for &FieldInfo { ref self_, span, name, .. } in fields {
+                	// FIXME: Use cx.bug for properly handling unnamed fields.
+                    stmts.push(call_nbt_fmt(span, self_.clone(), name.unwrap().clone()));
+                }
+
+                let close_nbt_path = pathexpr!(cx, trait_span, nbt::serialize::close_nbt);
+
+                let close = cx.expr_call(trait_span, close_nbt_path, vec![dst_expr.clone()]);
+                
+                cx.expr_block(cx.block(trait_span, stmts, Some(close)))
+            }
+        },
+        EnumMatching(..) => {
+            cx.span_err(trait_span,
+                        "`NbtFmt` cannot yet be derived for enums.");
+            cx.expr_fail(trait_span, InternedString::new(""))
+        },
+        EnumNonMatchingCollapsed(..) => {
+            cx.span_bug(trait_span,
+                        "non-matching enum variants in `#[derive(NbtFmt)]`")
+        },
+        StaticEnum(..) | StaticStruct(..) => {
+            cx.span_bug(trait_span, "static method in `#[derive(NbtFmt)]`")
+        },
+    }
+}

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -7,7 +7,6 @@
 //! 
 //! extern crate nbt;
 //! 
-//! use nbt::NbtError;
 //! use nbt::serialize::{NbtFmt, to_writer};
 //! 
 //! #[derive(NbtFmt)]
@@ -28,7 +27,7 @@
 //! 
 //! ```ignore
 //! impl NbtFmt for MyMob {
-//!     fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//!     fn to_bare_nbt<W>(&self, dst: &mut W) -> nbt::Result<()>
 //!        where W: std::io::Write
 //!     {
 //!         try!(self.name.to_nbt(dst, "name"));
@@ -109,13 +108,13 @@ pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
                 // Pass a single argument of type `&mut __W`.
                 args: vec!(Ptr(Box::new(Literal(w_arg)),
                                Borrowed(None, Mutability::MutMutable))),
-                // Return a `Result<(), nbt::NbtError>`.
+                // Return a `Result<(), nbt::Error>`.
                 ret_ty: Literal(Path::new_(
                     pathvec!(std::result::Result),
                     None,
                     vec!(Box::new(Tuple(Vec::new())), // Unit.
-                         Box::new(Literal(Path::new_( // nbt::NbtError
-                             pathvec!(nbt::NbtError),
+                         Box::new(Literal(Path::new_( // nbt::Error
+                             pathvec!(nbt::Error),
                              None, Vec::new(), true)))),
                     true)),
                 attributes: Vec::new(), // FIXME: Benchmark adding #[inline].

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -28,11 +28,11 @@
 //! 
 //! ```ignore
 //! impl NbtFmt for MyMob {
-//! 	fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//! 	fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
 //! 	   where W: std::io::Write
 //! 	{
-//! 		try!(self.name.write_nbt_fmt_with_name(dst, "name"));
-//!         try!(self.health.write_nbt_fmt_with_name(dst, "health"));
+//! 		try!(self.name.to_nbt(dst, "name"));
+//!         try!(self.health.to_nbt(dst, "health"));
 //! 
 //!         close_nbt(dst)
 //! 	}
@@ -97,7 +97,7 @@ pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
         generics: LifetimeBounds::empty(),
         methods: vec!(
             MethodDef {
-                name: "write_nbt_fmt",
+                name: "to_bare_nbt",
                 generics: LifetimeBounds {
                     lifetimes: Vec::new(),
                     // This adds a <__W: std::io::Writer> generic to the method.
@@ -131,7 +131,7 @@ pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
 }
 
 fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
-    // Retrieve the argument passed to the write_nbt_fmt function, i.e. the
+    // Retrieve the argument passed to the to_bare_nbt function, i.e. the
     // `dst: &mut __W` bit. Since the method is already defined, there's no
     // reason for this to fail, so we call `cx.span_bug` indicating a compiler
     // error.
@@ -143,7 +143,7 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
     };
     
     let call_nbt_fmt = |span, thing_expr, name| {
-        let nbt_fmt_path = pathexpr!(cx, span, nbt::serialize::NbtFmt::write_nbt_fmt_with_name);
+        let nbt_fmt_path = pathexpr!(cx, span, nbt::serialize::NbtFmt::to_nbt);
         let ref_thing = cx.expr_addr_of(span, thing_expr);
         
         // Create a string literal expression for the field's identifier.
@@ -171,7 +171,7 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
                             "`NbtFmt` has no meaning for unit structs.");
                 cx.expr_fail(trait_span, InternedString::new(""))
             } else if fields[0].name.is_none() {
-            	// FIXME: Handle tuple structs using write_nbt_fmt_with_name
+            	// FIXME: Handle tuple structs using to_nbt
             	// with name = "".
                 cx.span_err(trait_span,
                             "`NbtFmt` cannot yet be derived for tuple structs.");

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -1,4 +1,4 @@
-//! This crate contains a compiler plugin to generate NBT binary format
+//! This crate contains a compiler plugin to generate Named Binary Tag format
 //! serialization code for custom structs. It can be used as follows:
 //!
 //! ```ignore
@@ -12,8 +12,8 @@
 //! 
 //! #[derive(NbtFmt)]
 //! struct MyMob {
-//! 	name: String,
-//! 	health: i8
+//!     name: String,
+//!     health: i8
 //! }
 //!
 //! fn main() {
@@ -28,14 +28,14 @@
 //! 
 //! ```ignore
 //! impl NbtFmt for MyMob {
-//! 	fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
-//! 	   where W: std::io::Write
-//! 	{
-//! 		try!(self.name.to_nbt(dst, "name"));
+//!     fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//!        where W: std::io::Write
+//!     {
+//!         try!(self.name.to_nbt(dst, "name"));
 //!         try!(self.health.to_nbt(dst, "health"));
 //! 
 //!         close_nbt(dst)
-//! 	}
+//!     }
 //! }
 //! ```
 //! 
@@ -78,17 +78,17 @@ macro_rules! path {
 }
 
 macro_rules! pathexpr {
-	($cx:ident, $span:ident, $($x:ident)::+) => (
-		$cx.expr_path($cx.path_global($span,
-			vec![ $( $cx.ident_of( stringify!($x) ) ),+ ]))
-	)
+    ($cx:ident, $span:ident, $($x:ident)::+) => (
+        $cx.expr_path($cx.path_global($span,
+            vec![ $( $cx.ident_of( stringify!($x) ) ),+ ]))
+    )
 }
 
 pub fn expand_derive_nbtfmt(cx: &mut ExtCtxt, span: Span, meta_item: &MetaItem,
                             item: &Annotatable,
                             push: &mut FnMut(Annotatable))
 {
-	let w_arg = Path::new_local("__W");
+    let w_arg = Path::new_local("__W");
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
@@ -164,15 +164,15 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
     
     match *substr.fields {
         Struct(ref fields) => {   
-        	// Unit structs are kind of irrelevant for NBT, so throw an error
-        	// if someone tries to derive(NbtFmt) over one.         
+            // Unit structs are kind of irrelevant for NBT, so throw an error
+            // if someone tries to derive(NbtFmt) over one.
             if fields.is_empty() {
                 cx.span_err(trait_span,
                             "`NbtFmt` has no meaning for unit structs.");
                 cx.expr_fail(trait_span, InternedString::new(""))
             } else if fields[0].name.is_none() {
-            	// FIXME: Handle tuple structs using to_nbt
-            	// with name = "".
+                // FIXME: Handle tuple structs using to_nbt with each name as
+                //  "field0", etc.
                 cx.span_err(trait_span,
                             "`NbtFmt` cannot yet be derived for tuple structs.");
                 cx.expr_fail(trait_span, InternedString::new(""))
@@ -180,7 +180,7 @@ fn cs_nbtfmt(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Exp
                 let mut stmts = Vec::new();
 
                 for &FieldInfo { ref self_, span, name, .. } in fields {
-                	// FIXME: Use cx.bug for properly handling unnamed fields.
+                    // FIXME: Use cx.bug for properly handling unnamed fields.
                     stmts.push(call_nbt_fmt(span, self_.clone(), name.unwrap().clone()));
                 }
 

--- a/macros/tests.rs
+++ b/macros/tests.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, test, custom_derive)]
+#![feature(plugin, test, custom_derive, custom_attribute)]
 #![plugin(nbt_macros)]
 
 extern crate nbt;
@@ -11,7 +11,8 @@ struct TestStruct {
     name: String,
     health: i8,
     food: f32,
-    emeralds: i16,
+    #[nbt_field = "emeralds"]
+    ems: i16,
     timestamp: i32
 }
 
@@ -23,7 +24,7 @@ struct TestTupleStruct(i8, i8, f32);
 fn nbt_test_struct_serialize() {
   let test = TestStruct {
     name: "Herobrine".to_string(),
-    health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774
+    health: 100, food: 20.0, ems: 12345, timestamp: 1424778774
   };
 
   let mut dst = Vec::new();

--- a/macros/tests.rs
+++ b/macros/tests.rs
@@ -13,7 +13,11 @@ struct TestStruct {
     food: f32,
     emeralds: i16,
     timestamp: i32
-  }
+}
+
+#[allow(dead_code)]
+#[derive(NbtFmt)]
+struct TestTupleStruct(i8, i8, f32);
 
 #[test]
 fn nbt_test_struct_serialize() {

--- a/macros/tests.rs
+++ b/macros/tests.rs
@@ -1,0 +1,56 @@
+#![feature(plugin, test, custom_derive)]
+#![plugin(nbt_macros)]
+
+extern crate nbt;
+extern crate test;
+
+use nbt::serialize::NbtFmt;
+
+#[derive(NbtFmt)]
+struct TestStruct {
+    name: String,
+    health: i8,
+    food: f32,
+    emeralds: i16,
+    timestamp: i32
+  }
+
+#[test]
+fn nbt_test_struct_serialize() {
+  let test = TestStruct {
+    name: "Herobrine".to_string(),
+    health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774
+  };
+
+  let mut test_encoded = Vec::new();
+  test.write_nbt_fmt_with_name(&mut test_encoded, "").unwrap();
+
+  let bytes = [
+        0x0a,
+            0x00, 0x00,
+            0x08,
+                0x00, 0x04,
+                0x6e, 0x61, 0x6d, 0x65,
+                0x00, 0x09,
+                0x48, 0x65, 0x72, 0x6f, 0x62, 0x72, 0x69, 0x6e, 0x65,
+            0x01,
+                0x00, 0x06,
+                0x68, 0x65, 0x61, 0x6c, 0x74, 0x68,
+                0x64,
+            0x05,
+                0x00, 0x04,
+                0x66, 0x6f, 0x6f, 0x64,
+                0x41, 0xa0, 0x00, 0x00,
+            0x02,
+                0x00, 0x08,
+                0x65, 0x6d, 0x65, 0x72, 0x61, 0x6c, 0x64, 0x73,
+                0x30, 0x39,
+            0x03,
+                0x00, 0x09,
+                0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70,
+                0x54, 0xec, 0x66, 0x16,
+        0x00
+    ];
+
+    assert_eq!(&bytes[..], &test_encoded[..]);
+}

--- a/macros/tests.rs
+++ b/macros/tests.rs
@@ -4,7 +4,7 @@
 extern crate nbt;
 extern crate test;
 
-use nbt::serialize::NbtFmt;
+use nbt::serialize;
 
 #[derive(NbtFmt)]
 struct TestStruct {
@@ -22,8 +22,8 @@ fn nbt_test_struct_serialize() {
     health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774
   };
 
-  let mut test_encoded = Vec::new();
-  test.write_nbt_fmt_with_name(&mut test_encoded, "").unwrap();
+  let mut dst = Vec::new();
+  serialize::to_writer(&mut dst, test).unwrap();
 
   let bytes = [
         0x0a,
@@ -52,5 +52,5 @@ fn nbt_test_struct_serialize() {
         0x00
     ];
 
-    assert_eq!(&bytes[..], &test_encoded[..]);
+    assert_eq!(&bytes[..], &dst[..]);
 }

--- a/macros/tests.rs
+++ b/macros/tests.rs
@@ -16,21 +16,17 @@ struct TestStruct {
     timestamp: i32
 }
 
-#[allow(dead_code)]
-#[derive(NbtFmt)]
-struct TestTupleStruct(i8, i8, f32);
-
 #[test]
 fn nbt_test_struct_serialize() {
-  let test = TestStruct {
-    name: "Herobrine".to_string(),
-    health: 100, food: 20.0, ems: 12345, timestamp: 1424778774
-  };
+    let test = TestStruct {
+        name: "Herobrine".to_string(),
+        health: 100, food: 20.0, ems: 12345, timestamp: 1424778774
+    };
 
-  let mut dst = Vec::new();
-  serialize::to_writer(&mut dst, test).unwrap();
+    let mut dst = Vec::new();
+    serialize::to_writer(&mut dst, test).unwrap();
 
-  let bytes = [
+    let bytes = [
         0x0a,
             0x00, 0x00,
             0x08,

--- a/macros/tests/compile-fail/bad_nbt_field.rs
+++ b/macros/tests/compile-fail/bad_nbt_field.rs
@@ -1,0 +1,8 @@
+#![feature(plugin, custom_derive, custom_attribute)]
+#![plugin(nbt_macros)]
+
+#[derive(NbtFmt)]
+struct Simple {
+    #[nbt_field]
+    names: String, //~ ERROR `#[nbt_field]` requires a &str value.
+}

--- a/macros/tests/compile-fail/enums.rs
+++ b/macros/tests/compile-fail/enums.rs
@@ -1,0 +1,12 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+// Should throw the error twice --- once for each field.
+
+#[derive(NbtFmt)]
+      //~^ ERROR `NbtFmt` cannot yet be derived for enums.
+      //~^^ ERROR `NbtFmt` cannot yet be derived for enums.
+enum TestEnum {
+    Variant1,
+    Variant2
+}

--- a/macros/tests/compile-fail/missing_extern.rs
+++ b/macros/tests/compile-fail/missing_extern.rs
@@ -1,0 +1,17 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+// This throws many, many errors.
+
+#[derive(NbtFmt)]
+      //~^ ERROR failed to resolve. Maybe a missing `extern crate nbt`?
+      //~^^ ERROR use of undeclared trait name `nbt::serialize::NbtFmt`
+      //~^^^ ERROR failed to resolve. Maybe a missing `extern crate nbt`?
+      //~^^^^ ERROR use of undeclared type name `nbt::Error`
+      //~^^^^^ ERROR failed to resolve. Maybe a missing `extern crate nbt`?
+      //~^^^^^^ ERROR unresolved name `nbt::serialize::close_nbt`
+struct One {
+	byte: i8
+	//~^ ERROR failed to resolve. Maybe a missing `extern crate nbt`?
+    //~^^ ERROR unresolved name `nbt::serialize::NbtFmt::to_nbt`
+}

--- a/macros/tests/compile-fail/no_field_impl.rs
+++ b/macros/tests/compile-fail/no_field_impl.rs
@@ -1,0 +1,16 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+extern crate nbt;
+
+struct Inner {
+    name: String
+}
+
+#[derive(NbtFmt)]
+struct Outer {
+    name: String,
+    inner: Inner //~ ERROR the trait `nbt::serialize::NbtFmt` is not implemented for the type `Inner`
+}
+
+fn main() { }

--- a/macros/tests/compile-fail/unitstruct.rs
+++ b/macros/tests/compile-fail/unitstruct.rs
@@ -1,0 +1,5 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+#[derive(NbtFmt)] //~ ERROR `NbtFmt` has no meaning for unit structs.
+struct UnitStruct;

--- a/macros/tests/compiletest.rs
+++ b/macros/tests/compiletest.rs
@@ -1,0 +1,26 @@
+extern crate compiletest_rs as compiletest;
+
+use compiletest::common::Mode;
+
+use std::path::PathBuf;
+
+#[test]
+fn test_compilation() {
+    let mut config = compiletest::default_config();
+
+    // Test compilation failures.
+
+    config.mode = Mode::CompileFail;
+    config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps".to_string());
+    config.src_base = PathBuf::from("tests/compile-fail");
+    config.verbose = true;
+
+    compiletest::run_tests(&config);
+
+    // Test compilation successes.
+
+    config.mode = Mode::RunPass;
+    config.src_base = PathBuf::from("tests/run-pass");
+
+    compiletest::run_tests(&config);
+}

--- a/macros/tests/run-pass/inner.rs
+++ b/macros/tests/run-pass/inner.rs
@@ -1,0 +1,17 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+extern crate nbt;
+
+#[derive(NbtFmt)]
+struct Inner {
+    name: String
+}
+
+#[derive(NbtFmt)]
+struct Outer {
+    name: String,
+    inner: Inner
+}
+
+fn main() { }

--- a/macros/tests/run-pass/nbt_field.rs
+++ b/macros/tests/run-pass/nbt_field.rs
@@ -1,0 +1,12 @@
+#![feature(plugin, custom_derive, custom_attribute)]
+#![plugin(nbt_macros)]
+
+extern crate nbt;
+
+#[derive(NbtFmt)]
+struct Simple {
+    #[nbt_field = "names"]
+    n: String,
+}
+
+fn main() { }

--- a/macros/tests/run-pass/tuplestruct.rs
+++ b/macros/tests/run-pass/tuplestruct.rs
@@ -1,0 +1,9 @@
+#![feature(plugin, custom_derive)]
+#![plugin(nbt_macros)]
+
+extern crate nbt;
+
+#[derive(NbtFmt)]
+struct TupleStruct(i8, i8, String);
+
+fn main() { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,10 @@ pub use blob::NbtBlob;
 pub use error::{Error, Result};
 pub use value::NbtValue;
 
+pub mod serialize;
+
 mod blob;
 mod error;
 mod value;
+
 #[cfg(test)] mod tests;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 use std::io;
 
 use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
@@ -40,56 +42,73 @@ pub fn to_writer<W, T>(dst: &mut W, obj: T) -> Result<(), NbtError>
 }
 
 macro_rules! nbtfmt_value {
-  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+  ($T:ty, $method:ident, $tag:expr) => (
     impl NbtFmt for $T {
-      fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
-           where W: io::Write {
+        #[inline]
+        fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write
+        {
             $method(dst, *self)
-      }
+        }
+
         #[inline] fn tag() -> u8 { $tag }
-        #[inline] fn is_bare() -> bool { $bare }
+        #[inline] fn is_bare() -> bool { true }
     }
   )
 }
 
 macro_rules! nbtfmt_ptr {
-  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+  ($T:ty, $method:ident, $tag:expr) => (
     impl NbtFmt for $T {
-      fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
-           where W: io::Write {
+        #[inline]
+        fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write
+        {
             $method(dst, self)
-      }
+        }
+
         #[inline] fn tag() -> u8 { $tag }
-        #[inline] fn is_bare() -> bool { $bare }
+        #[inline] fn is_bare() -> bool { true }
     }
   )
 }
 
 macro_rules! nbtfmt_slice {
-  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+  ($T:ty, $method:ident, $tag:expr) => (
     impl NbtFmt for $T {
-      fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
-           where W: io::Write {
+        #[inline]
+        fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write
+        {
             $method(dst, &self[..])
-      }
+        }
+
         #[inline] fn tag() -> u8 { $tag }
-        #[inline] fn is_bare() -> bool { $bare }
+        #[inline] fn is_bare() -> bool { true }
     }
   )
 }
 
-nbtfmt_value!(i8, write_bare_byte, 0x01, true);
-nbtfmt_value!(i16, write_bare_short, 0x02, true);
-nbtfmt_value!(i32, write_bare_int, 0x03, true);
-nbtfmt_value!(i64, write_bare_long, 0x04, true);
-nbtfmt_value!(f32, write_bare_float, 0x05, true);
-nbtfmt_value!(f64, write_bare_double, 0x06, true);
-nbtfmt_ptr!([i8], write_bare_byte_array, 0x07, true);
-nbtfmt_slice!(Vec<i8>, write_bare_byte_array, 0x07, true);
-nbtfmt_ptr!(str, write_bare_string, 0x08, true);
-nbtfmt_slice!(String, write_bare_string, 0x08, true);
-nbtfmt_ptr!([i32], write_bare_int_array, 0x0b, true);
-nbtfmt_slice!(Vec<i32>, write_bare_int_array, 0x0b, true);
+nbtfmt_value!(i8, write_bare_byte, 0x01);
+nbtfmt_value!(i16, write_bare_short, 0x02);
+nbtfmt_value!(i32, write_bare_int, 0x03);
+nbtfmt_value!(i64, write_bare_long, 0x04);
+nbtfmt_value!(f32, write_bare_float, 0x05);
+nbtfmt_value!(f64, write_bare_double, 0x06);
+nbtfmt_ptr!(str, write_bare_string, 0x08);
+nbtfmt_slice!(String, write_bare_string, 0x08);
+
+// For now, to handle conflicting implementations, use slices to indicate when
+// byte and int arrays should be preferred to lists.
+
+nbtfmt_ptr!([i8], write_bare_byte_array, 0x07);
+nbtfmt_ptr!([i32], write_bare_int_array, 0x0b);
+
+// FIXME: Remove this workaround and enable some way of uncommenting the lines
+// that follow.
+
+// nbtfmt_slice!(Vec<i8>, write_bare_byte_array, 0x07);
+// nbtfmt_slice!(Vec<i32>, write_bare_int_array, 0x0b);
 
 // impl<T> NbtFmt for [T] where T: NbtFmt {
 //  fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
@@ -101,15 +120,43 @@ nbtfmt_slice!(Vec<i32>, write_bare_int_array, 0x0b, true);
 //     #[inline] fn is_bare() -> bool { true }
 // }
 
-// impl<T> NbtFmt for Vec<T> where T: NbtFmt {
-//  fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
-//        where W: io::Write {
-        
-//          write_bare_list(dst, self.iter())
-//  }
-//     #[inline] fn tag() -> u8 { 0x09 }
-//     #[inline] fn is_bare() -> bool { true }
-// }
+// This leaves Vec<T> alone for lists (which kind of makes sense).
+
+impl<T> NbtFmt for Vec<T> where T: NbtFmt {
+    #[inline]
+    fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+       where W: io::Write
+    {
+           write_bare_list(dst, self.iter())
+    }
+
+    #[inline] fn tag() -> u8 { 0x09 }
+    #[inline] fn is_bare() -> bool { true }
+}
+
+impl<S, T> NbtFmt for HashMap<S, T> where S: AsRef<str> + Hash + Eq, T: NbtFmt {
+    #[inline]
+    fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+       where W: io::Write
+    {
+        write_bare_compound(dst, self.iter())
+    }
+
+    #[inline] fn tag() -> u8 { 0x0a }
+    #[inline] fn is_bare() -> bool { false }
+}
+
+impl<S, T> NbtFmt for BTreeMap<S, T> where S: AsRef<str>, T: NbtFmt {
+    #[inline]
+    fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+       where W: io::Write
+    {
+        write_bare_compound(dst, self.iter())
+    }
+
+    #[inline] fn tag() -> u8 { 0x0a }
+    #[inline] fn is_bare() -> bool { false }
+}
 
 #[inline]
 fn write_bare_byte<W>(dst: &mut W, value: i8) -> Result<(), NbtError>
@@ -218,13 +265,15 @@ fn write_bare_compound<'a, W, I, T, S>(dst: &mut W, values: I) -> Result<(), Nbt
 }
 
 #[test]
-fn nbt_test_struct_serialize() {
+fn serialize_basic_types() {
   struct TestStruct {
     name: String,
     health: i8,
     food: f32,
     emeralds: i16,
-    timestamp: i32
+    timestamp: i32,
+    ids: HashMap<String, i8>,
+    data: Vec<i8>
   }
 
   impl NbtFmt for TestStruct {
@@ -236,6 +285,8 @@ fn nbt_test_struct_serialize() {
             try!(self.food.to_nbt(dst, "food"));
             try!(self.emeralds.to_nbt(dst, "emeralds"));
             try!(self.timestamp.to_nbt(dst, "timestamp"));
+            try!(self.ids.to_nbt(dst, "ids"));
+            try!(self.data.to_nbt(dst, "data"));
 
             close_nbt(dst)
         }
@@ -243,11 +294,12 @@ fn nbt_test_struct_serialize() {
 
   let test = TestStruct {
     name: "Herobrine".to_string(),
-    health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774
+    health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774,
+    ids: HashMap::new(), data: vec![1, 2, 3]
   };
 
-  let mut test_encoded = Vec::new();
-  to_writer(&mut dst, test);
+  let mut dst = Vec::new();
+  to_writer(&mut dst, test).unwrap();
 
   let bytes = [
         0x0a,
@@ -273,8 +325,19 @@ fn nbt_test_struct_serialize() {
                 0x00, 0x09,
                 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70,
                 0x54, 0xec, 0x66, 0x16,
+            0x0a,
+                0x00, 0x03,
+                0x69, 0x64, 0x73,
+                // No content.
+            0x00,
+            0x09,
+                0x00, 0x04,
+                0x64, 0x61, 0x74, 0x61,
+                0x01, // List type.
+                0x00, 0x00, 0x00, 0x03, // Length.
+                0x01, 0x02, 0x03, // Content.
         0x00
     ];
 
-    assert_eq!(&bytes[..], &test_encoded[..]);
+    assert_eq!(&bytes[..], &dst[..]);
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,262 @@
+use std::io;
+
+use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
+
+use error::NbtError;
+
+pub trait NbtFmt {
+    fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+       where W: io::Write;
+
+    #[inline]
+    fn write_nbt_fmt_with_name<W, S>(&self, dst: &mut W, name: S) -> Result<(), NbtError>
+       where W: io::Write,
+             S: AsRef<str> {
+
+        try!(dst.write_u8(Self::tag()));
+        try!(write_bare_string(dst, name.as_ref()));
+        self.write_nbt_fmt(dst)
+    }
+    
+    #[inline] fn tag() -> u8 { 0x0a }
+    #[inline] fn is_bare() -> bool { false }
+}
+
+macro_rules! nbtfmt_value {
+  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+    impl NbtFmt for $T {
+      fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write {
+            $method(dst, *self)
+      }
+        #[inline] fn tag() -> u8 { $tag }
+        #[inline] fn is_bare() -> bool { $bare }
+    }
+  )
+}
+
+macro_rules! nbtfmt_ptr {
+  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+    impl NbtFmt for $T {
+      fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write {
+            $method(dst, self)
+      }
+        #[inline] fn tag() -> u8 { $tag }
+        #[inline] fn is_bare() -> bool { $bare }
+    }
+  )
+}
+
+macro_rules! nbtfmt_slice {
+  ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
+    impl NbtFmt for $T {
+      fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write {
+            $method(dst, &self[..])
+      }
+        #[inline] fn tag() -> u8 { $tag }
+        #[inline] fn is_bare() -> bool { $bare }
+    }
+  )
+}
+
+nbtfmt_value!(i8, write_bare_byte, 0x01, true);
+nbtfmt_value!(i16, write_bare_short, 0x02, true);
+nbtfmt_value!(i32, write_bare_int, 0x03, true);
+nbtfmt_value!(i64, write_bare_long, 0x04, true);
+nbtfmt_value!(f32, write_bare_float, 0x05, true);
+nbtfmt_value!(f64, write_bare_double, 0x06, true);
+nbtfmt_ptr!([i8], write_bare_byte_array, 0x07, true);
+nbtfmt_slice!(Vec<i8>, write_bare_byte_array, 0x07, true);
+nbtfmt_ptr!(str, write_bare_string, 0x08, true);
+nbtfmt_slice!(String, write_bare_string, 0x08, true);
+nbtfmt_ptr!([i32], write_bare_int_array, 0x0b, true);
+nbtfmt_slice!(Vec<i32>, write_bare_int_array, 0x0b, true);
+
+// impl<T> NbtFmt for [T] where T: NbtFmt {
+//  fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//        where W: io::Write {
+        
+//          write_bare_list(dst, self.iter())
+//  }
+//     #[inline] fn tag() -> u8 { 0x09 }
+//     #[inline] fn is_bare() -> bool { true }
+// }
+
+// impl<T> NbtFmt for Vec<T> where T: NbtFmt {
+//  fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+//        where W: io::Write {
+        
+//          write_bare_list(dst, self.iter())
+//  }
+//     #[inline] fn tag() -> u8 { 0x09 }
+//     #[inline] fn is_bare() -> bool { true }
+// }
+
+#[inline]
+fn write_bare_byte<W>(dst: &mut W, value: i8) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_i8(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_short<W>(dst: &mut W, value: i16) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_i16::<BigEndian>(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_int<W>(dst: &mut W, value: i32) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_i32::<BigEndian>(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_long<W>(dst: &mut W, value: i64) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_i64::<BigEndian>(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_float<W>(dst: &mut W, value: f32) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_f32::<BigEndian>(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_double<W>(dst: &mut W, value: f64) -> Result<(), NbtError>
+   where W: io::Write {
+
+    dst.write_f64::<BigEndian>(value).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_byte_array<W>(dst: &mut W, value: &[i8]) -> Result<(), NbtError>
+   where W: io::Write {
+
+    try!(dst.write_i32::<BigEndian>(value.len() as i32));
+    for &v in value {
+        try!(dst.write_i8(v));
+    }
+    Ok(())
+}
+
+#[inline]
+fn write_bare_int_array<W>(dst: &mut W, value: &[i32]) -> Result<(), NbtError>
+   where W: io::Write {
+
+    try!(dst.write_i32::<BigEndian>(value.len() as i32));
+    for &v in value {
+        try!(dst.write_i32::<BigEndian>(v));
+    }
+    Ok(())
+}
+
+#[inline]
+fn write_bare_string<W>(dst: &mut W, value: &str) -> Result<(), NbtError>
+   where W: io::Write {
+    
+    try!(dst.write_u16::<BigEndian>(value.len() as u16));
+    dst.write_all(value.as_bytes()).map_err(From::from)
+}
+
+#[inline]
+fn write_bare_list<'a, W, I, T>(dst: &mut W, values: I) -> Result<(), NbtError>
+   where W: io::Write,
+         I: Iterator<Item=&'a T> + ExactSizeIterator,
+         T: 'a + NbtFmt {
+
+    // The list contents are prefixed by a byte tag for the type and the
+    // length of the list (a big-endian i32).
+    try!(dst.write_u8(T::tag()));
+    try!(dst.write_i32::<BigEndian>(values.len() as i32));
+
+    for ref value in values {
+       try!(value.write_nbt_fmt(dst));
+    }
+
+    Ok(())
+}
+
+#[inline]
+fn write_bare_compound<'a, W, I, T, S>(dst: &mut W, values: I) -> Result<(), NbtError>
+   where W: io::Write,
+         I: Iterator<Item=(&'a S, &'a T)>,
+         S: 'a + AsRef<str>,
+         T: 'a + NbtFmt {
+
+    for (key, ref value) in values {
+        try!(value.write_nbt_fmt_with_name(dst, key.as_ref()));
+    }
+    
+    // Write the marker for the end of the Compound.
+    dst.write_u8(0x00).map_err(From::from)
+}
+
+#[test]
+fn nbt_test_struct_serialize() {
+  struct TestStruct {
+    name: String,
+    health: i8,
+    food: f32,
+    emeralds: i16,
+    timestamp: i32
+  }
+
+  impl NbtFmt for TestStruct {
+    fn write_nbt_fmt<W>(&self, dst: &mut W) -> Result<(), NbtError>
+           where W: io::Write {
+
+            self.name.write_nbt_fmt_with_name(dst, "name");
+            self.health.write_nbt_fmt_with_name(dst, "health");
+            self.food.write_nbt_fmt_with_name(dst, "food");
+            self.emeralds.write_nbt_fmt_with_name(dst, "emeralds");
+            self.timestamp.write_nbt_fmt_with_name(dst, "timestamp");
+
+            dst.write_u8(0x00).map_err(From::from)
+        }
+  }
+
+  let test = TestStruct {
+    name: "Herobrine".to_string(),
+    health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774
+  };
+
+  let mut test_encoded = Vec::new();
+  test.write_nbt_fmt_with_name(&mut test_encoded, "");
+
+  let bytes = [
+        0x0a,
+            0x00, 0x00,
+            0x08,
+                0x00, 0x04,
+                0x6e, 0x61, 0x6d, 0x65,
+                0x00, 0x09,
+                0x48, 0x65, 0x72, 0x6f, 0x62, 0x72, 0x69, 0x6e, 0x65,
+            0x01,
+                0x00, 0x06,
+                0x68, 0x65, 0x61, 0x6c, 0x74, 0x68,
+                0x64,
+            0x05,
+                0x00, 0x04,
+                0x66, 0x6f, 0x6f, 0x64,
+                0x41, 0xa0, 0x00, 0x00,
+            0x02,
+                0x00, 0x08,
+                0x65, 0x6d, 0x65, 0x72, 0x61, 0x6c, 0x64, 0x73,
+                0x30, 0x39,
+            0x03,
+                0x00, 0x09,
+                0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70,
+                0x54, 0xec, 0x66, 0x16,
+        0x00
+    ];
+
+    assert_eq!(&bytes[..], &test_encoded[..]);
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -22,6 +22,19 @@ pub trait NbtFmt {
     #[inline] fn is_bare() -> bool { false }
 }
 
+pub fn close_nbt<W>(dst: &mut W) -> Result<(), NbtError>
+    where W: io::Write {
+
+    dst.write_u8(0x00).map_err(From::from)
+}
+
+pub fn to_writer<W, T>(dst: &mut W, obj: T) -> Result<(), NbtError>
+    where W: io::Write,
+          T: NbtFmt
+{
+    obj.write_nbt_fmt_with_name(dst, "")
+}
+
 macro_rules! nbtfmt_value {
   ($T:ty, $method:ident, $tag:expr, $bare:expr) => (
     impl NbtFmt for $T {


### PR DESCRIPTION
Builds on #5, but contains the actual meat. This is the second part of my [PR #90 on hematite_server](https://github.com/PistonDevelopers/hematite_server/pull/90). It adds a compiler plugin that implements a method of `NbtFmt` on any reasonable struct candidate using `#[derive(NbtFmt)]`.

This is a work-in-progress. Outstanding tasks before it's ready to merge:

- [x] Choose better names for the trait methods.
- [x] Document `NbtFmt`, `to_writer`, and `close_nbt`.
- [x] More comments in the compiler plugin.
- [x] A few edge cases in the plugin.

*Edit: outstanding tasks now complete.*