### PR TITLE
Move to Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly
+rust: beta
 notifications:
   irc: "irc.mozilla.org#hematite"
 script:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! MC Named Binary Tag type.
 
-#![feature(iter_arith)]
 #![cfg_attr(test, feature(test))]
 
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 //! MC Named Binary Tag type.
 
-#![cfg_attr(test, feature(test))]
-
 extern crate byteorder;
 extern crate flate2;
-#[cfg(test)] extern crate test;
 
 /* Re-export the core API from submodules. */
 pub use blob::Blob;

--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -30,11 +30,11 @@ pub mod raw;
 /// ```ignore
 /// #![feature(plugin, custom_derive)]
 /// #![plugin(nbt_macros)]
-/// 
+///
 /// extern crate nbt;
-/// 
+///
 /// use nbt::serialize::{NbtFmt, to_writer};
-/// 
+///
 /// #[derive(NbtFmt)]
 /// struct MyMob {
 ///     name: String,
@@ -142,7 +142,7 @@ pub trait NbtFmt {
         try!(raw::write_bare_string(dst, name.as_ref()));
         self.to_bare_nbt(dst)
     }
-    
+
     /// Indicates the NBT tag that this type corresponds to. Most custom types
     /// (usually structs) will advertise the default, `0x0a`, which is the
     /// default.
@@ -322,7 +322,7 @@ nbtfmt_ptr!([i32], Vec<i32>, raw::read_bare_int_array, raw::write_bare_int_array
 // impl<T> NbtFmt for [T] where T: NbtFmt {
 //  fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<()>
 //        where W: io::Write {
-        
+
 //          write_bare_list(dst, self.iter())
 //  }
 //     #[inline] fn tag() -> u8 { 0x09 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io;
 use std::fs::File;
 
-use test::Bencher;
+//use test::Bencher;
 
 use blob::Blob;
 use error::{Error, Result};
@@ -237,23 +237,23 @@ fn nbt_bigtest() {
     assert_eq!(1544, bigtest.len());
 }
 
-#[bench]
-fn nbt_bench_bigwrite(b: &mut Bencher) {
-    let mut file = File::open("tests/big1.nbt").unwrap();
-    let nbt = Blob::from_gzip(&mut file).unwrap();
-    b.iter(|| {
-        nbt.write(&mut io::sink())
-    });
-}
+//#[bench]
+//fn nbt_bench_bigwrite(b: &mut Bencher) {
+//    let mut file = File::open("tests/big1.nbt").unwrap();
+//    let nbt = Blob::from_gzip(&mut file).unwrap();
+//    b.iter(|| {
+//        nbt.write(&mut io::sink())
+//    });
+//}
 
-#[bench]
-fn nbt_bench_smallwrite(b: &mut Bencher) {
-    let mut file = File::open("tests/small4.nbt").unwrap();
-    let nbt = Blob::from_reader(&mut file).unwrap();
-    b.iter(|| {
-        nbt.write(&mut io::sink())
-    });
-}
+//#[bench]
+//fn nbt_bench_smallwrite(b: &mut Bencher) {
+//    let mut file = File::open("tests/small4.nbt").unwrap();
+//    let nbt = Blob::from_reader(&mut file).unwrap();
+//    b.iter(|| {
+//        nbt.write(&mut io::sink())
+//    });
+//}
 
 #[test]
 fn serialize_basic_types() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -71,13 +71,13 @@ impl Value {
             Value::String(ref val)    => 2 + val.len(), // size + bytes
             Value::List(ref vals)     => {
                 // tag + size + payload for each element
-                5 + vals.iter().map(|x| x.len()).sum::<usize>()
+                5 + vals.iter().map(|x| x.len()).fold(0, |acc, item| acc + item)
             },
             Value::Compound(ref vals) => {
                 vals.iter().map(|(name, nbt)| {
                     // tag + name + payload for each entry
                     3 + name.len() + nbt.len()
-                }).sum::<usize>() + 1 // + u8 for the Tag_End
+                }).fold(0, |acc, item| acc + item) + 1 // + u8 for the Tag_End
             },
             Value::IntArray(ref val)  => 4 + 4 * val.len(),
         }


### PR DESCRIPTION
This removes the use of unstable features, allowing the crate to build on beta. I consider this another important step toward publishing on [crates.io](https://crates.io/), since ideally a crate published there should compile on stable Rust (which should be the case when this is merged and 1.2 is released).

It also tells Travis CI to use the beta channel.