### PR TITLE
Accounts for the new default behaviour of associated types.

### DIFF
--- a/src/serialize/mod.rs
+++ b/src/serialize/mod.rs
@@ -119,7 +119,7 @@ pub mod raw;
 /// }
 /// ```
 pub trait NbtFmt {
-    type Into: Sized = Self;
+    type Into: Sized;
 
     /// Convert this type to NBT format using the specified `io::Write`
     /// destination, but does not serialize its identifying NBT tag or name.
@@ -230,6 +230,8 @@ pub fn read_bare_nbt<R, T>(src: &mut R) -> Result<T>
 macro_rules! nbtfmt_value {
   ($T:ty, $read_method:expr, $write_method:expr, $tag:expr) => (
     impl NbtFmt for $T {
+        type Into = $T;
+
         #[inline]
         fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<()>
            where W: io::Write
@@ -278,6 +280,8 @@ macro_rules! nbtfmt_ptr {
 macro_rules! nbtfmt_slice {
   ($T:ty, $read_method:expr, $write_method:expr, $tag:expr) => (
     impl NbtFmt for $T {
+        type Into = $T;
+
         #[inline]
         fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<()>
            where W: io::Write

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -255,83 +255,85 @@ fn nbt_bigtest() {
 //    });
 //}
 
+#[derive(Debug, Clone, PartialEq)]
+struct TestStruct {
+    name: String,
+    health: i8,
+    food: f32,
+    emeralds: i16,
+    timestamp: i32,
+    ids: HashMap<String, i8>,
+    data: Vec<i8>
+}
+
+impl NbtFmt for TestStruct {
+        type Into = TestStruct;
+
+    fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<()>
+       where W: io::Write {
+
+        try!(self.name.to_nbt(dst, "name"));
+        try!(self.health.to_nbt(dst, "health"));
+        try!(self.food.to_nbt(dst, "food"));
+        try!(self.emeralds.to_nbt(dst, "emeralds"));
+        try!(self.timestamp.to_nbt(dst, "timestamp"));
+        try!(self.ids.to_nbt(dst, "ids"));
+        try!(self.data.to_nbt(dst, "data"));
+
+        close_nbt(dst)
+    }
+
+    fn read_bare_nbt<R>(src: &mut R) -> Result<TestStruct>
+        where R: io::Read
+    {
+        let mut name: String = Default::default();
+        let mut health: i8 = Default::default();
+        let mut food: f32 = Default::default();
+        let mut emeralds: i16 = Default::default();
+        let mut timestamp: i32 = Default::default();
+        let mut ids: HashMap<String, i8> = Default::default();
+        let mut data: Vec<i8> = Default::default();
+
+        loop {
+            let (t, n) = try!(emit_next_header(src));
+
+            if t == 0x00 { break; } // i.e. Tag_End
+
+            match &n[..] {
+                "name" => {
+                    name = try!(read_bare_nbt(src));
+                },
+                "health" => {
+                    health = try!(read_bare_nbt(src));
+                },
+                "food" => {
+                    food = try!(read_bare_nbt(src));
+                },
+                "emeralds" => {
+                    emeralds = try!(read_bare_nbt(src));
+                },
+                "timestamp" => {
+                    timestamp = try!(read_bare_nbt(src));
+                },
+                "ids" => {
+                    ids = try!(read_bare_nbt(src));
+                },
+                "data" => {
+                    data = try!(read_bare_nbt(src));
+                },
+                e => { return Err(Error::UnexpectedField(e.to_string())); }
+            };
+        }
+
+        Ok(TestStruct {
+            name: name, health: health, food: food, emeralds: emeralds,
+            timestamp: timestamp, ids: ids, data: data
+        })
+    }
+}
+
 #[test]
 fn serialize_basic_types() {
-    #[derive(Debug, Clone, PartialEq)]
-    struct TestStruct {
-        name: String,
-        health: i8,
-        food: f32,
-        emeralds: i16,
-        timestamp: i32,
-        ids: HashMap<String, i8>,
-        data: Vec<i8>
-    }
-
-    impl NbtFmt for TestStruct {
-        fn to_bare_nbt<W>(&self, dst: &mut W) -> Result<()>
-           where W: io::Write {
-
-            try!(self.name.to_nbt(dst, "name"));
-            try!(self.health.to_nbt(dst, "health"));
-            try!(self.food.to_nbt(dst, "food"));
-            try!(self.emeralds.to_nbt(dst, "emeralds"));
-            try!(self.timestamp.to_nbt(dst, "timestamp"));
-            try!(self.ids.to_nbt(dst, "ids"));
-            try!(self.data.to_nbt(dst, "data"));
-
-            close_nbt(dst)
-        }
-
-        fn read_bare_nbt<R>(src: &mut R) -> Result<TestStruct>
-            where R: io::Read
-        {
-            let mut name: String = Default::default();
-            let mut health: i8 = Default::default();
-            let mut food: f32 = Default::default();
-            let mut emeralds: i16 = Default::default();
-            let mut timestamp: i32 = Default::default();
-            let mut ids: HashMap<String, i8> = Default::default();
-            let mut data: Vec<i8> = Default::default();
-
-            loop {
-                let (t, n) = try!(emit_next_header(src));
-
-                if t == 0x00 { break; } // i.e. Tag_End
-
-                match &n[..] {
-                    "name" => {
-                        name = try!(read_bare_nbt(src));
-                    },
-                    "health" => {
-                        health = try!(read_bare_nbt(src));
-                    },
-                    "food" => {
-                        food = try!(read_bare_nbt(src));
-                    },
-                    "emeralds" => {
-                        emeralds = try!(read_bare_nbt(src));
-                    },
-                    "timestamp" => {
-                        timestamp = try!(read_bare_nbt(src));
-                    },
-                    "ids" => {
-                        ids = try!(read_bare_nbt(src));
-                    },
-                    "data" => {
-                        data = try!(read_bare_nbt(src));
-                    },
-                    e => { return Err(Error::UnexpectedField(e.to_string())); }
-                };
-            }
-
-            Ok(TestStruct {
-                name: name, health: health, food: food, emeralds: emeralds,
-                timestamp: timestamp, ids: ids, data: data
-            })
-        }
-    }
-
     let test = TestStruct {
         name: "Herobrine".to_string(),
         health: 100, food: 20.0, emeralds: 12345, timestamp: 1424778774,


### PR DESCRIPTION
Also fixes a small indentation issue in one of the tests, although git isn't diff'ing very clearly. This is to account for the new rules on nightly builds, and shouldn't break anything.

The canonical discussion of defaults for associated types is [here](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-items.md#defaults).