### PR TITLE
Move to stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-rust: beta
 notifications:
   irc: "irc.mozilla.org#hematite"
 script:


### PR DESCRIPTION
This tells Travis CI to use the stable channel. No code changes were necessary.