### PR TITLE
Remove wildcard dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ name = "nbt"
 path = "src/lib.rs"
 
 [dependencies]
-byteorder = "*"
-flate2 = "*"
+byteorder = "0.4"
+flate2 = "0.2"


### PR DESCRIPTION
As `cargo package` warns:

> warning: some dependencies have wildcard ("*") version constraints. On December 11th, 2015, crates.io will begin rejecting packages with wildcard dependency constraints. See http://doc.crates.io/crates-io.html#using-crates.io-based-crates for information on version constraints.

This changes the wildcards to regular semver compatibility constraints.