### PR TITLE
Improve README and library documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,92 @@
 # hematite_nbt [![Build Status](https://travis-ci.org/PistonDevelopers/hematite_nbt.svg?branch=master)](https://travis-ci.org/PistonDevelopers/hematite_nbt)
 
-This is a [Rust][] library for working with [Minecraft][]'s Named Binary Tag (NBT) file format. It is maintained by the [Hematite][] project, and is used in the [Hematite server][].
+`hematite-nbt` is a Rust library for reading and writing Minecraft's
+[Named Binary Tag file format](http://minecraft.gamepedia.com/NBT_format) (NBT).
 
-Unlike the Hematite server, this library should be functional, and may be published on [crates.io][] soon.
+This crate is maintained by the [Hematite][] project, and is used in the
+[Hematite server][].
+
+## Basic Usage
+
+The `nbt` crate can be used to read and write NBT-format streams. NBT-format
+files are represented as `Blob` objects, which contain NBT-compatible `Value`
+elements. For example:
+
+```rust
+use nbt::{Blob, Value};
+
+// Create a `Blob` from key/value pairs.
+let mut nbt = Blob::new("".to_string());
+nbt.insert("name".to_string(), "Herobrine").unwrap();
+nbt.insert("health".to_string(), 100i8).unwrap();
+nbt.insert("food".to_string(), 20.0f32).unwrap();
+
+// Write a compressed binary representation to a byte array.
+let mut dst = Vec::new();
+nbt.write_zlib(&mut dst).unwrap();
+```
+
+As of 0.3, the API is still experimental, and may change in future versions.
+
+## Usage with `serde_derive`
+
+This repository also contains an `nbt-serde` crate that supports reading and
+writing the NBT format using the [`serde` framework][]. This enables
+automatically deriving serialization/deserialization of user-defined types,
+bypassing the use of the generic `Blob` and `Value` types illustrated above.
+
+For example:
+
+``` rust
+#[macro_use] extern crate serde_derive;
+extern crate serde;
+extern crate nbt_serde;
+
+use nbt_serde::encode::to_writer;
+
+#[derive(Debug, PartialEq, Serialize)]
+struct MyNbt {
+    name: String,
+    score: i8,
+}
+
+fn main() {
+    let nbt = MyNbt { name: "Herobrine".to_string(), score: 42 };
+
+    let mut dst = Vec::new();
+    to_writer(&mut dst, &nbt, None).unwrap();
+
+    let read: MyNbt = from_reader(&dst[..]).unwrap();
+
+    assert_eq!(read, nbt);
+}
+```
+
+This approach can be considerably faster if one knows the data encoded in the
+incoming NBT stream beforehand.
+
+## Installation
+
+Neither `nbt` nor `nbt_serde` is available on [crates.io][]. However, they can
+still be listed as a dependency in your `Cargo.toml` file as follows:
+
+``` toml
+[dependencies]
+hematite-nbt = { git = "https://github.com/PistonDevelopers/hematite_nbt.git" }
+hematite-nbt-serde = { git = "https://github.com/PistonDevelopers/hematite_nbt.git" }
+```
+
+(You can also clone the repository into a subdirectory and specify the crates as
+a dependency with `path = "..."` if you wish.)
+
+## License
+
+All code is available under the terms of the MIT license. See the `LICENSE` file
+for details.
 
 [Hematite]: http://hematite.piston.rs/ (Hematite)
 [Hematite server]: https://github.com/PistonDevelopers/hematite_server (github: PistonDevelopers: hematite_server)
 [Minecraft]: https://minecraft.net/ (Minecraft)
 [Rust]: http://www.rust-lang.org/ (The Rust Programming Language)
 [crates.io]: https://crates.io/ (crates.io)
+[`serde` framework]: https://serde.rs/

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,12 +10,12 @@ use value::Value;
 
 #[test]
 fn nbt_nonempty() {
-    let mut nbt = Blob::new("".to_string());
-    nbt.insert("name".to_string(),      "Herobrine").unwrap();
-    nbt.insert("health".to_string(),    100i8).unwrap();
-    nbt.insert("food".to_string(),      20.0f32).unwrap();
-    nbt.insert("emeralds".to_string(),  12345i16).unwrap();
-    nbt.insert("timestamp".to_string(), 1424778774i32).unwrap();
+    let mut nbt = Blob::new();
+    nbt.insert("name", "Herobrine").unwrap();
+    nbt.insert("health", 100i8).unwrap();
+    nbt.insert("food", 20.0f32).unwrap();
+    nbt.insert("emeralds", 12345i16).unwrap();
+    nbt.insert("timestamp", 1424778774i32).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -57,7 +57,7 @@ fn nbt_nonempty() {
 
 #[test]
 fn nbt_empty_nbtfile() {
-    let nbt = Blob::new("".to_string());
+    let nbt = Blob::new();
 
     let bytes = vec![
         0x0a,
@@ -83,8 +83,8 @@ fn nbt_empty_nbtfile() {
 fn nbt_nested_compound() {
     let mut inner = HashMap::new();
     inner.insert("test".to_string(), Value::Byte(123));
-    let mut nbt = Blob::new("".to_string());
-    nbt.insert("inner".to_string(), Value::Compound(inner)).unwrap();
+    let mut nbt = Blob::new();
+    nbt.insert("inner", Value::Compound(inner)).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -116,8 +116,8 @@ fn nbt_nested_compound() {
 
 #[test]
 fn nbt_empty_list() {
-    let mut nbt = Blob::new("".to_string());
-    nbt.insert("list".to_string(), Value::List(Vec::new())).unwrap();
+    let mut nbt = Blob::new();
+    nbt.insert("list", Value::List(Vec::new())).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -186,12 +186,12 @@ fn nbt_invalid_id() {
 
 #[test]
 fn nbt_invalid_list() {
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     let mut badlist = Vec::new();
     badlist.push(Value::Byte(1));
     badlist.push(Value::Short(1));
     // Will fail to insert, because the List is heterogeneous.
-    assert_eq!(nbt.insert("list".to_string(), Value::List(badlist)),
+    assert_eq!(nbt.insert("list", Value::List(badlist)),
                Err(Error::HeterogeneousList));
 }
 
@@ -206,12 +206,12 @@ fn nbt_bad_compression() {
 #[test]
 fn nbt_compression() {
     // Create a non-trivial Blob.
-    let mut nbt = Blob::new("".to_string());
-    nbt.insert("name".to_string(), Value::String("Herobrine".to_string())).unwrap();
-    nbt.insert("health".to_string(), Value::Byte(100)).unwrap();
-    nbt.insert("food".to_string(), Value::Float(20.0)).unwrap();
-    nbt.insert("emeralds".to_string(), Value::Short(12345)).unwrap();
-    nbt.insert("timestamp".to_string(), Value::Int(1424778774)).unwrap();
+    let mut nbt = Blob::new();
+    nbt.insert("name", Value::String("Herobrine".to_string())).unwrap();
+    nbt.insert("health", Value::Byte(100)).unwrap();
+    nbt.insert("food", Value::Float(20.0)).unwrap();
+    nbt.insert("emeralds", Value::Short(12345)).unwrap();
+    nbt.insert("timestamp", Value::Int(1424778774)).unwrap();
 
     // Test zlib encoding/decoding.
     let mut zlib_dst = Vec::new();


### PR DESCRIPTION
*This is a work in progress. Do not merge.*

This PR improves the documentation of the `nbt` crate and adds a much more detailed `README.md` file for the project.

It also contains small changes to improve the ergonomics of working with `Blob` objects, so that creating/modifying NBT data has a clearer API. These changes are detailed in the new documentation and examples for that struct.