### PR TITLE
Revisit the Blob, Value, and ser/de API

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -136,16 +136,6 @@ impl Blob {
         self.content.insert(name.into(), nvalue);
         Ok(())
     }
-
-    /// The uncompressed length of this `Blob`, in bytes.
-    pub fn len(&self) -> usize {
-        // tag + name + content
-        let header = 1 + 2 + self.title.len();
-        let content = self.content.iter().map(|(name, nbt)| {
-            3 + name.len() + nbt.len()
-        }).fold(0, |acc, item| acc + item);
-        header + content + 1
-    }
 }
 
 impl<'a> Index<&'a str> for Blob {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -88,7 +88,8 @@ impl Blob {
         dst.write_u8(0x0a)?;
         raw::write_bare_string(&mut dst, &self.title)?;
         for (name, ref nbt) in self.content.iter() {
-            nbt.write_header(&mut dst, &name)?;
+            dst.write_u8(nbt.id())?;
+            raw::write_bare_string(&mut dst, name)?;
             nbt.write(&mut dst)?;
         }
         raw::close_nbt(&mut dst)

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -27,9 +27,9 @@ use value::Value;
 ///
 /// // Create a `Blob` from key/value pairs.
 /// let mut nbt = Blob::new();
-/// nbt.insert("name".to_string(), "Herobrine").unwrap();
-/// nbt.insert("health".to_string(), 100i8).unwrap();
-/// nbt.insert("food".to_string(), 20.0f32).unwrap();
+/// nbt.insert("name", "Herobrine").unwrap();
+/// nbt.insert("health", 100i8).unwrap();
+/// nbt.insert("food", 20.0f32).unwrap();
 ///
 /// // Write a compressed binary representation to a byte array.
 /// let mut dst = Vec::new();
@@ -113,8 +113,8 @@ impl Blob {
     /// This method will also return an error if a `Value::List` with
     /// heterogeneous elements is passed in, because this is illegal in the NBT
     /// file format.
-    pub fn insert<V>(&mut self, name: String, value: V) -> Result<()>
-           where V: Into<Value> {
+    pub fn insert<S, V>(&mut self, name: S, value: V) -> Result<()>
+           where S: Into<String>, V: Into<Value> {
         // The follow prevents `List`s with heterogeneous tags from being
         // inserted into the file.
         let nvalue = value.into();
@@ -128,7 +128,7 @@ impl Blob {
                 }
             }
         }
-        self.content.insert(name, nvalue);
+        self.content.insert(name.into(), nvalue);
         Ok(())
     }
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -116,8 +116,7 @@ impl Blob {
     pub fn insert<V>(&mut self, name: String, value: V) -> Result<()>
            where V: Into<Value> {
         // The follow prevents `List`s with heterogeneous tags from being
-        // inserted into the file. It would be nicer to return an error, but
-        // this would depart from the `HashMap` API for `insert`.
+        // inserted into the file.
         let nvalue = value.into();
         if let Value::List(ref vals) = nvalue {
             if vals.len() != 0 {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -53,17 +53,17 @@ impl Blob {
     }
 
     /// Extracts an `Blob` object from an `io::Read` source.
-    pub fn from_reader(src: &mut io::Read) -> Result<Blob> {
-        let header = try!(Value::read_header(src));
+    pub fn from_reader(mut src: &mut io::Read) -> Result<Blob> {
+        let (tag, title) = try!(raw::emit_next_header(&mut src));
         // Although it would be possible to read NBT format files composed of
         // arbitrary objects using the current API, by convention all files
         // have a top-level Compound.
-        if header.0 != 0x0a {
+        if tag != 0x0a {
             return Err(Error::NoRootCompound);
         }
-        let content = try!(Value::from_reader(header.0, src));
+        let content = try!(Value::from_reader(tag, src));
         match content {
-            Value::Compound(map) => Ok(Blob { title: header.1, content: map }),
+            Value::Compound(map) => Ok(Blob { title: title, content: map }),
             _ => Err(Error::NoRootCompound),
         }
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -26,7 +26,7 @@ use value::Value;
 /// use nbt::{Blob, Value};
 ///
 /// // Create a `Blob` from key/value pairs.
-/// let mut nbt = Blob::new("".to_string());
+/// let mut nbt = Blob::new();
 /// nbt.insert("name".to_string(), "Herobrine").unwrap();
 /// nbt.insert("health".to_string(), 100i8).unwrap();
 /// nbt.insert("food".to_string(), 20.0f32).unwrap();
@@ -42,9 +42,14 @@ pub struct Blob {
 }
 
 impl Blob {
+    /// Create a new NBT file format representation with an empty name.
+    pub fn new() -> Blob {
+        Blob { title: "".to_string(), content: HashMap::new() }
+    }
+
     /// Create a new NBT file format representation with the given name.
-    pub fn new(title: String) -> Blob {
-        Blob { title: title, content: HashMap::new() }
+    pub fn named<S>(name: S) -> Blob where S: Into<String> {
+        Blob { title: name.into(), content: HashMap::new() }
     }
 
     /// Extracts an `Blob` object from an `io::Read` source.

--- a/src/de.rs
+++ b/src/de.rs
@@ -25,7 +25,7 @@ pub fn from_reader<R, T>(src: R) -> Result<T>
 ///
 /// Note that only maps and structs can be decoded, because the NBT format does
 /// not support bare types. Other types will return `Error::NoRootCompound`.
-pub fn from_gzip<R, T>(src: R) -> Result<T>
+pub fn from_gzip_reader<R, T>(src: R) -> Result<T>
     where R: io::Read,
           T: de::DeserializeOwned,
 {
@@ -37,7 +37,7 @@ pub fn from_gzip<R, T>(src: R) -> Result<T>
 ///
 /// Note that only maps and structs can be decoded, because the NBT format does
 /// not support bare types. Other types will return `Error::NoRootCompound`.
-pub fn from_zlib<R, T>(src: R) -> Result<T>
+pub fn from_zlib_reader<R, T>(src: R) -> Result<T>
     where R: io::Read,
           T: de::DeserializeOwned,
 {

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,3 +1,5 @@
+//! Deserialize Named Binary Tag data to a Rust data structure.
+
 use std::io;
 
 use serde::de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use blob::Blob;
 pub use error::{Error, Result};
 pub use value::Value;
 
-pub mod raw;
+mod raw;
 mod blob;
 mod error;
 mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,13 @@ pub use blob::Blob;
 pub use error::{Error, Result};
 pub use value::Value;
 
+#[cfg(feature = "serde")]
+#[doc(inline)]
+pub use de::{from_reader, from_gzip_reader, from_zlib_reader};
+#[cfg(feature = "serde")]
+#[doc(inline)]
+pub use ser::{to_writer, to_gzip_writer, to_zlib_writer};
+
 mod raw;
 mod blob;
 mod error;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,11 +1,4 @@
 //! Primitive functions for serializing and deserializing NBT data.
-//!
-//! This submodule is not intended for general use, but is exposed for those
-//! interested in writing fast NBT encoding/decoding by hand, where it may be
-//! quite useful.
-//!
-//! A high-level API for reading and writing generic NBT data is available in
-//! the [`Blob`](../struct.Blob.html) struct.
 
 use std::io;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -4,6 +4,8 @@ use std::io;
 
 use serde;
 use serde::ser;
+use flate2::Compression;
+use flate2::write::{GzEncoder, ZlibEncoder};
 
 use raw;
 
@@ -18,6 +20,28 @@ pub fn to_writer<'a, W, T>(dst: &mut W, value: &T, header: Option<&'a str>)
           T: ?Sized + ser::Serialize,
 {
     let mut encoder = Encoder::new(dst, header);
+    value.serialize(&mut encoder)
+}
+
+/// Encode `value` in Named Binary Tag format to the given `io::Write`
+/// destination, with an optional header.
+pub fn to_gzip_writer<'a, W, T>(dst: &mut W, value: &T, header: Option<&'a str>)
+                           -> Result<()>
+    where W: ?Sized + io::Write,
+          T: ?Sized + ser::Serialize,
+{
+    let mut encoder = Encoder::new(GzEncoder::new(dst, Compression::Default), header);
+    value.serialize(&mut encoder)
+}
+
+/// Encode `value` in Named Binary Tag format to the given `io::Write`
+/// destination, with an optional header.
+pub fn to_zlib_writer<'a, W, T>(dst: &mut W, value: &T, header: Option<&'a str>)
+                           -> Result<()>
+    where W: ?Sized + io::Write,
+          T: ?Sized + ser::Serialize,
+{
+    let mut encoder = Encoder::new(ZlibEncoder::new(dst, Compression::Default), header);
     value.serialize(&mut encoder)
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,3 +1,5 @@
+//! Serialize a Rust data structure into Named Binary Tag data.
+
 use std::io;
 
 use serde;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,11 +11,11 @@ use value::Value;
 #[test]
 fn nbt_nonempty() {
     let mut nbt = Blob::new();
-    nbt.insert("name".to_string(),      "Herobrine").unwrap();
-    nbt.insert("health".to_string(),    100i8).unwrap();
-    nbt.insert("food".to_string(),      20.0f32).unwrap();
-    nbt.insert("emeralds".to_string(),  12345i16).unwrap();
-    nbt.insert("timestamp".to_string(), 1424778774i32).unwrap();
+    nbt.insert("name", "Herobrine").unwrap();
+    nbt.insert("health", 100i8).unwrap();
+    nbt.insert("food", 20.0f32).unwrap();
+    nbt.insert("emeralds", 12345i16).unwrap();
+    nbt.insert("timestamp", 1424778774i32).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -84,7 +84,7 @@ fn nbt_nested_compound() {
     let mut inner = HashMap::new();
     inner.insert("test".to_string(), Value::Byte(123));
     let mut nbt = Blob::new();
-    nbt.insert("inner".to_string(), Value::Compound(inner)).unwrap();
+    nbt.insert("inner", Value::Compound(inner)).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -117,7 +117,7 @@ fn nbt_nested_compound() {
 #[test]
 fn nbt_empty_list() {
     let mut nbt = Blob::new();
-    nbt.insert("list".to_string(), Value::List(Vec::new())).unwrap();
+    nbt.insert("list", Value::List(Vec::new())).unwrap();
 
     let bytes = vec![
         0x0a,
@@ -191,7 +191,7 @@ fn nbt_invalid_list() {
     badlist.push(Value::Byte(1));
     badlist.push(Value::Short(1));
     // Will fail to insert, because the List is heterogeneous.
-    assert_eq!(nbt.insert("list".to_string(), Value::List(badlist)),
+    assert_eq!(nbt.insert("list", Value::List(badlist)),
                Err(Error::HeterogeneousList));
 }
 
@@ -207,11 +207,11 @@ fn nbt_bad_compression() {
 fn nbt_compression() {
     // Create a non-trivial Blob.
     let mut nbt = Blob::new();
-    nbt.insert("name".to_string(), Value::String("Herobrine".to_string())).unwrap();
-    nbt.insert("health".to_string(), Value::Byte(100)).unwrap();
-    nbt.insert("food".to_string(), Value::Float(20.0)).unwrap();
-    nbt.insert("emeralds".to_string(), Value::Short(12345)).unwrap();
-    nbt.insert("timestamp".to_string(), Value::Int(1424778774)).unwrap();
+    nbt.insert("name", Value::String("Herobrine".to_string())).unwrap();
+    nbt.insert("health", Value::Byte(100)).unwrap();
+    nbt.insert("food", Value::Float(20.0)).unwrap();
+    nbt.insert("emeralds", Value::Short(12345)).unwrap();
+    nbt.insert("timestamp", Value::Int(1424778774)).unwrap();
 
     // Test zlib encoding/decoding.
     let mut zlib_dst = Vec::new();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ use value::Value;
 
 #[test]
 fn nbt_nonempty() {
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     nbt.insert("name".to_string(),      "Herobrine").unwrap();
     nbt.insert("health".to_string(),    100i8).unwrap();
     nbt.insert("food".to_string(),      20.0f32).unwrap();
@@ -57,7 +57,7 @@ fn nbt_nonempty() {
 
 #[test]
 fn nbt_empty_nbtfile() {
-    let nbt = Blob::new("".to_string());
+    let nbt = Blob::new();
 
     let bytes = vec![
         0x0a,
@@ -83,7 +83,7 @@ fn nbt_empty_nbtfile() {
 fn nbt_nested_compound() {
     let mut inner = HashMap::new();
     inner.insert("test".to_string(), Value::Byte(123));
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     nbt.insert("inner".to_string(), Value::Compound(inner)).unwrap();
 
     let bytes = vec![
@@ -116,7 +116,7 @@ fn nbt_nested_compound() {
 
 #[test]
 fn nbt_empty_list() {
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     nbt.insert("list".to_string(), Value::List(Vec::new())).unwrap();
 
     let bytes = vec![
@@ -186,7 +186,7 @@ fn nbt_invalid_id() {
 
 #[test]
 fn nbt_invalid_list() {
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     let mut badlist = Vec::new();
     badlist.push(Value::Byte(1));
     badlist.push(Value::Short(1));
@@ -206,7 +206,7 @@ fn nbt_bad_compression() {
 #[test]
 fn nbt_compression() {
     // Create a non-trivial Blob.
-    let mut nbt = Blob::new("".to_string());
+    let mut nbt = Blob::new();
     nbt.insert("name".to_string(), Value::String("Herobrine".to_string())).unwrap();
     nbt.insert("health".to_string(), Value::Byte(100)).unwrap();
     nbt.insert("food".to_string(), Value::Float(20.0)).unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,7 +45,9 @@ fn nbt_nonempty() {
     ];
 
     // Test correct length.
-    assert_eq!(bytes.len(), nbt.len());
+    let mut dst = Vec::new();
+    nbt.write(&mut dst).unwrap();
+    assert_eq!(bytes.len(), dst.len());
 
     // We can only test if the decoded bytes match, since the HashMap does
     // not guarantee order (and so encoding is likely to be different, but
@@ -64,9 +66,6 @@ fn nbt_empty_nbtfile() {
             0x00, 0x00,
         0x00
     ];
-
-    // Test correct length.
-    assert_eq!(bytes.len(), nbt.len());
 
     // Test encoding.
     let mut dst = Vec::new();
@@ -100,9 +99,6 @@ fn nbt_nested_compound() {
         0x00
     ];
 
-    // Test correct length.
-    assert_eq!(bytes.len(), nbt.len());
-
     // Test encoding.
     let mut dst = Vec::new();
     nbt.write(&mut dst).unwrap();
@@ -129,9 +125,6 @@ fn nbt_empty_list() {
                 0x00, 0x00, 0x00, 0x00,
         0x00
     ];
-
-    // Test correct length.
-    assert_eq!(bytes.len(), nbt.len());
 
     // Test encoding.
     let mut dst = Vec::new();
@@ -231,7 +224,9 @@ fn nbt_bigtest() {
     let mut bigtest_file = File::open("tests/big1.nbt").unwrap();
     let bigtest = Blob::from_gzip(&mut bigtest_file).unwrap();
     // This is a pretty indirect way of testing correctness.
-    assert_eq!(1544, bigtest.len());
+    let mut dst = Vec::new();
+    bigtest.write(&mut dst).unwrap();
+    assert_eq!(1544, dst.len());
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ fn nbt_nonempty() {
 
     // Test correct length.
     let mut dst = Vec::new();
-    nbt.write(&mut dst).unwrap();
+    nbt.to_writer(&mut dst).unwrap();
     assert_eq!(bytes.len(), dst.len());
 
     // We can only test if the decoded bytes match, since the HashMap does
@@ -69,7 +69,7 @@ fn nbt_empty_nbtfile() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.write(&mut dst).unwrap();
+    nbt.to_writer(&mut dst).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
@@ -101,7 +101,7 @@ fn nbt_nested_compound() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.write(&mut dst).unwrap();
+    nbt.to_writer(&mut dst).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
@@ -128,7 +128,7 @@ fn nbt_empty_list() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.write(&mut dst).unwrap();
+    nbt.to_writer(&mut dst).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
@@ -192,8 +192,8 @@ fn nbt_invalid_list() {
 fn nbt_bad_compression() {
     // These aren't in the zlib or gzip format, so they'll fail.
     let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    assert!(Blob::from_gzip(&mut io::Cursor::new(&bytes[..])).is_err());
-    assert!(Blob::from_zlib(&mut io::Cursor::new(&bytes[..])).is_err());
+    assert!(Blob::from_gzip_reader(&mut io::Cursor::new(&bytes[..])).is_err());
+    assert!(Blob::from_zlib_reader(&mut io::Cursor::new(&bytes[..])).is_err());
 }
 
 #[test]
@@ -208,24 +208,24 @@ fn nbt_compression() {
 
     // Test zlib encoding/decoding.
     let mut zlib_dst = Vec::new();
-    nbt.write_zlib(&mut zlib_dst).unwrap();
-    let zlib_file = Blob::from_zlib(&mut io::Cursor::new(zlib_dst)).unwrap();
+    nbt.to_zlib_writer(&mut zlib_dst).unwrap();
+    let zlib_file = Blob::from_zlib_reader(&mut io::Cursor::new(zlib_dst)).unwrap();
     assert_eq!(&nbt, &zlib_file);
 
     // Test gzip encoding/decoding.
     let mut gzip_dst = Vec::new();
-    nbt.write_gzip(&mut gzip_dst).unwrap();
-    let gz_file = Blob::from_gzip(&mut io::Cursor::new(gzip_dst)).unwrap();
+    nbt.to_gzip_writer(&mut gzip_dst).unwrap();
+    let gz_file = Blob::from_gzip_reader(&mut io::Cursor::new(gzip_dst)).unwrap();
     assert_eq!(&nbt, &gz_file);
 }
 
 #[test]
 fn nbt_bigtest() {
     let mut bigtest_file = File::open("tests/big1.nbt").unwrap();
-    let bigtest = Blob::from_gzip(&mut bigtest_file).unwrap();
+    let bigtest = Blob::from_gzip_reader(&mut bigtest_file).unwrap();
     // This is a pretty indirect way of testing correctness.
     let mut dst = Vec::new();
-    bigtest.write(&mut dst).unwrap();
+    bigtest.to_writer(&mut dst).unwrap();
     assert_eq!(1544, dst.len());
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -89,16 +89,18 @@ impl Value {
     }
 
     /// Writes the payload of this `Value` to an `io::Write` destination.
-    pub fn write(&self, mut dst: &mut io::Write) -> Result<()> {
+    pub fn to_writer<W>(&self, mut dst: &mut W) -> Result<()>
+        where W: io::Write
+    {
         match *self {
-            Value::Byte(val)   => raw::write_bare_byte(&mut dst, val),
-            Value::Short(val)  => raw::write_bare_short(&mut dst, val),
-            Value::Int(val)    => raw::write_bare_int(&mut dst, val),
-            Value::Long(val)   => raw::write_bare_long(&mut dst, val),
-            Value::Float(val)  => raw::write_bare_float(&mut dst, val),
-            Value::Double(val) => raw::write_bare_double(&mut dst, val),
-            Value::ByteArray(ref vals) => raw::write_bare_byte_array(&mut dst, &vals[..]),
-            Value::String(ref val) => raw::write_bare_string(&mut dst, &val),
+            Value::Byte(val)   => raw::write_bare_byte(dst, val),
+            Value::Short(val)  => raw::write_bare_short(dst, val),
+            Value::Int(val)    => raw::write_bare_int(dst, val),
+            Value::Long(val)   => raw::write_bare_long(dst, val),
+            Value::Float(val)  => raw::write_bare_float(dst, val),
+            Value::Double(val) => raw::write_bare_double(dst, val),
+            Value::ByteArray(ref vals) => raw::write_bare_byte_array(dst, &vals[..]),
+            Value::String(ref val) => raw::write_bare_string(dst, &val),
             Value::List(ref vals) => {
                 // This is a bit of a trick: if the list is empty, don't bother
                 // checking its type.
@@ -115,7 +117,7 @@ impl Value {
                         if nbt.id() != first_id {
                             return Err(Error::HeterogeneousList);
                         }
-                        try!(nbt.write(dst));
+                        try!(nbt.to_writer(dst));
                     }
                 }
                 Ok(())
@@ -124,28 +126,30 @@ impl Value {
                 for (name, ref nbt) in vals {
                     // Write the header for the tag.
                     dst.write_u8(nbt.id())?;
-                    raw::write_bare_string(&mut dst, name)?;
-                    try!(nbt.write(dst));
+                    raw::write_bare_string(dst, name)?;
+                    try!(nbt.to_writer(dst));
                 }
                 raw::close_nbt(&mut dst)
             },
-            Value::IntArray(ref vals) => raw::write_bare_int_array(&mut dst, &vals[..]),
-            Value::LongArray(ref vals) => raw::write_bare_long_array(&mut dst, &vals[..]),
+            Value::IntArray(ref vals) => raw::write_bare_int_array(dst, &vals[..]),
+            Value::LongArray(ref vals) => raw::write_bare_long_array(dst, &vals[..]),
         }
     }
 
     /// Reads the payload of an `Value` with a given type ID from an
     /// `io::Read` source.
-    pub fn from_reader(id: u8, mut src: &mut io::Read) -> Result<Value> {
+    pub fn from_reader<R>(id: u8, src: &mut R) -> Result<Value>
+        where R: io::Read
+    {
         match id {
-            0x01 => Ok(Value::Byte(raw::read_bare_byte(&mut src)?)),
-            0x02 => Ok(Value::Short(raw::read_bare_short(&mut src)?)),
-            0x03 => Ok(Value::Int(raw::read_bare_int(&mut src)?)),
-            0x04 => Ok(Value::Long(raw::read_bare_long(&mut src)?)),
-            0x05 => Ok(Value::Float(raw::read_bare_float(&mut src)?)),
-            0x06 => Ok(Value::Double(raw::read_bare_double(&mut src)?)),
-            0x07 => Ok(Value::ByteArray(raw::read_bare_byte_array(&mut src)?)),
-            0x08 => Ok(Value::String(raw::read_bare_string(&mut src)?)),
+            0x01 => Ok(Value::Byte(raw::read_bare_byte(src)?)),
+            0x02 => Ok(Value::Short(raw::read_bare_short(src)?)),
+            0x03 => Ok(Value::Int(raw::read_bare_int(src)?)),
+            0x04 => Ok(Value::Long(raw::read_bare_long(src)?)),
+            0x05 => Ok(Value::Float(raw::read_bare_float(src)?)),
+            0x06 => Ok(Value::Double(raw::read_bare_double(src)?)),
+            0x07 => Ok(Value::ByteArray(raw::read_bare_byte_array(src)?)),
+            0x08 => Ok(Value::String(raw::read_bare_string(src)?)),
             0x09 => { // List
                 let id = try!(src.read_u8());
                 let len = try!(src.read_i32::<BigEndian>()) as usize;
@@ -158,15 +162,15 @@ impl Value {
             0x0a => { // Compound
                 let mut buf = HashMap::new();
                 loop {
-                    let (id, name) = try!(raw::emit_next_header(&mut src));
+                    let (id, name) = try!(raw::emit_next_header(src));
                     if id == 0x00 { break; }
                     let tag = try!(Value::from_reader(id, src));
                     buf.insert(name, tag);
                 }
                 Ok(Value::Compound(buf))
             },
-            0x0b => Ok(Value::IntArray(raw::read_bare_int_array(&mut src)?)),
-            0x0c => Ok(Value::LongArray(raw::read_bare_long_array(&mut src)?)),
+            0x0b => Ok(Value::IntArray(raw::read_bare_int_array(src)?)),
+            0x0c => Ok(Value::LongArray(raw::read_bare_long_array(src)?)),
             e => Err(Error::InvalidTypeId(e))
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -88,13 +88,6 @@ impl Value {
         }
     }
 
-    /// Writes the header (that is, the value's type ID and optionally a title)
-    /// of this `Value` to an `io::Write` destination.
-    pub fn write_header(&self, mut dst: &mut io::Write, title: &str) -> Result<()> {
-        try!(dst.write_u8(self.id()));
-        raw::write_bare_string(&mut dst, title)
-    }
-
     /// Writes the payload of this `Value` to an `io::Write` destination.
     pub fn write(&self, mut dst: &mut io::Write) -> Result<()> {
         match *self {
@@ -130,10 +123,10 @@ impl Value {
             Value::Compound(ref vals)  => {
                 for (name, ref nbt) in vals {
                     // Write the header for the tag.
-                    try!(nbt.write_header(dst, &name));
+                    dst.write_u8(nbt.id())?;
+                    raw::write_bare_string(&mut dst, name)?;
                     try!(nbt.write(dst));
                 }
-
                 raw::close_nbt(&mut dst)
             },
             Value::IntArray(ref vals) => raw::write_bare_int_array(&mut dst, &vals[..]),

--- a/src/value.rs
+++ b/src/value.rs
@@ -62,32 +62,6 @@ impl Value {
         }
     }
 
-    /// The length of the payload of this `Value`, in bytes.
-    pub fn len(&self) -> usize {
-        match *self {
-            Value::Byte(_)            => 1,
-            Value::Short(_)           => 2,
-            Value::Int(_)             => 4,
-            Value::Long(_)            => 8,
-            Value::Float(_)           => 4,
-            Value::Double(_)          => 8,
-            Value::ByteArray(ref val) => 4 + val.len(), // size + bytes
-            Value::String(ref val)    => 2 + val.len(), // size + bytes
-            Value::List(ref vals)     => {
-                // tag + size + payload for each element
-                5 + vals.iter().map(|x| x.len()).fold(0, |acc, item| acc + item)
-            },
-            Value::Compound(ref vals) => {
-                vals.iter().map(|(name, nbt)| {
-                    // tag + name + payload for each entry
-                    3 + name.len() + nbt.len()
-                }).fold(0, |acc, item| acc + item) + 1 // + u8 for the Tag_End
-            },
-            Value::IntArray(ref val)  => 4 + 4 * val.len(),
-            Value::LongArray(ref val) => 4 + 8 * val.len(),
-        }
-    }
-
     /// Writes the payload of this `Value` to an `io::Write` destination.
     pub fn to_writer<W>(&self, mut dst: &mut W) -> Result<()>
         where W: io::Write

--- a/src/value.rs
+++ b/src/value.rs
@@ -141,16 +141,6 @@ impl Value {
         }
     }
 
-    /// Reads any valid `Value` header (that is, a type ID and a title of
-    /// arbitrary UTF-8 bytes) from an `io::Read` source.
-    pub fn read_header(mut src: &mut io::Read) -> Result<(u8, String)> {
-        let id = try!(src.read_u8());
-        if id == 0x00 { return Ok((0x00, "".to_string())); }
-        // Extract the name.
-        let name = try!(raw::read_bare_string(&mut src));
-        Ok((id, name))
-    }
-
     /// Reads the payload of an `Value` with a given type ID from an
     /// `io::Read` source.
     pub fn from_reader(id: u8, mut src: &mut io::Read) -> Result<Value> {
@@ -175,7 +165,7 @@ impl Value {
             0x0a => { // Compound
                 let mut buf = HashMap::new();
                 loop {
-                    let (id, name) = try!(Value::read_header(src));
+                    let (id, name) = try!(raw::emit_next_header(&mut src));
                     if id == 0x00 { break; }
                     let tag = try!(Value::from_reader(id, src));
                     buf.insert(name, tag);

--- a/tests/filetests.rs
+++ b/tests/filetests.rs
@@ -9,7 +9,7 @@ extern crate nbt;
 
 use std::fs::File;
 
-use nbt::de::{from_reader, from_gzip};
+use nbt::de::{from_reader, from_gzip_reader};
 
 // Include structure definitions.
 include!("data.rs.in");
@@ -161,24 +161,24 @@ fn deserialize_big1() {
         int_test: 2147483647,
     };
     let mut file = File::open("tests/big1.nbt").unwrap();
-    let read: Big1 = from_gzip(&mut file).unwrap();
+    let read: Big1 = from_gzip_reader(&mut file).unwrap();
     assert_eq!(nbt, read)
 }
 
 #[test]
 fn deserialize_simple_player() {
     let mut file = File::open("tests/simple_player.dat").unwrap();
-    let _: PlayerData = from_gzip(&mut file).unwrap();
+    let _: PlayerData = from_gzip_reader(&mut file).unwrap();
 }
 
 #[test]
 fn deserialize_complex_player() {
     let mut file = File::open("tests/complex_player.dat").unwrap();
-    let _: PlayerData = from_gzip(&mut file).unwrap();
+    let _: PlayerData = from_gzip_reader(&mut file).unwrap();
 }
 
 #[test]
 fn deserialize_level() {
     let mut file = File::open("tests/level.dat").unwrap();
-    let _: Level = from_gzip(&mut file).unwrap();
+    let _: Level = from_gzip_reader(&mut file).unwrap();
 }


### PR DESCRIPTION
This PR makes a number of breaking changes in the interests of #33, as well as removing many methods that exposed implementation details for no good reason. The commit messages provide a fairly good summary of the changes and their rationale.