### PR TITLE
Add get method for Blob

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -144,6 +144,13 @@ impl Blob {
         self.content.insert(name.into(), nvalue);
         Ok(())
     }
+
+    /// Tries to get a named `Value` in the blob.
+    pub fn get<S>(&self, name: S) -> Option<&Value> 
+        where S: Into<&'static str>
+    {
+        self.content.get(name.into())
+    }
 }
 
 impl<'a> Index<&'a str> for Blob {


### PR DESCRIPTION
Currently [Blob](https://docs.rs/hematite-nbt/0.4.1/nbt/struct.Blob.html) does not have a method to try to get a value by name. The only way to get a value from a Blob is to index by name, which will panic if the value doesn't exist. This pull requests adds a method to get by name, returning an Option.