### PR TITLE
Add little-endian support

### DIFF
--- a/benches/filetests.rs
+++ b/benches/filetests.rs
@@ -15,8 +15,9 @@ use std::io::{self, Read};
 
 use test::Bencher;
 
-use nbt::de::from_gzip;
+use nbt::de::from_gzip_reader;
 use nbt::ser::to_writer;
+use nbt::Endianness;
 
 mod data {
     include!("../tests/data.rs.in");
@@ -29,7 +30,7 @@ fn deserialize_big1_as_struct(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        let _: data::Big1 = from_gzip(&mut src).unwrap();
+        let _: data::Big1 = from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
@@ -40,25 +41,25 @@ fn deserialize_big1_as_blob(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        nbt::Blob::from_gzip(&mut src).unwrap();
+        nbt::Blob::from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
 #[bench]
 fn serialize_big1_as_struct(b: &mut Bencher) {
     let mut file = File::open("tests/big1.nbt").unwrap();
-    let nbt: data::Big1 = from_gzip(&mut file).unwrap();
+    let nbt: data::Big1 = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        to_writer(&mut io::sink(), &nbt, None)
+        to_writer(&mut io::sink(), &nbt, None, Endianness::BigEndian)
     });
 }
 
 #[bench]
 fn serialize_big1_as_blob(b: &mut Bencher) {
     let mut file = File::open("tests/big1.nbt").unwrap();
-    let nbt = nbt::Blob::from_gzip(&mut file).unwrap();
+    let nbt = nbt::Blob::from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        nbt.write(&mut io::sink())
+        nbt.to_writer(&mut io::sink(), Endianness::BigEndian)
     });
 }
 #[bench]
@@ -68,7 +69,7 @@ fn deserialize_simple_player_as_struct(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        let _: data::PlayerData = from_gzip(&mut src).unwrap();
+        let _: data::PlayerData = from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
@@ -79,25 +80,25 @@ fn deserialize_simple_player_as_blob(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        nbt::Blob::from_gzip(&mut src).unwrap();
+        nbt::Blob::from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
 #[bench]
 fn serialize_simple_player_as_struct(b: &mut Bencher) {
     let mut file = File::open("tests/simple_player.dat").unwrap();
-    let nbt: data::PlayerData = from_gzip(&mut file).unwrap();
+    let nbt: data::PlayerData = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        to_writer(&mut io::sink(), &nbt, None)
+        to_writer(&mut io::sink(), &nbt, None, Endianness::BigEndian)
     });
 }
 
 #[bench]
 fn serialize_simple_player_as_blob(b: &mut Bencher) {
     let mut file = File::open("tests/simple_player.dat").unwrap();
-    let nbt = nbt::Blob::from_gzip(&mut file).unwrap();
+    let nbt = nbt::Blob::from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        nbt.write(&mut io::sink())
+        nbt.to_writer(&mut io::sink(), Endianness::BigEndian)
     });
 }
 
@@ -108,7 +109,7 @@ fn deserialize_complex_player_as_struct(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        let _: data::PlayerData = from_gzip(&mut src).unwrap();
+        let _: data::PlayerData = from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
@@ -119,25 +120,25 @@ fn deserialize_complex_player_as_blob(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        nbt::Blob::from_gzip(&mut src).unwrap();
+        nbt::Blob::from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
 #[bench]
 fn serialize_complex_player_as_struct(b: &mut Bencher) {
     let mut file = File::open("tests/complex_player.dat").unwrap();
-    let nbt: data::PlayerData = from_gzip(&mut file).unwrap();
+    let nbt: data::PlayerData = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        to_writer(&mut io::sink(), &nbt, None)
+        to_writer(&mut io::sink(), &nbt, None, Endianness::BigEndian)
     });
 }
 
 #[bench]
 fn serialize_complex_player_as_blob(b: &mut Bencher) {
     let mut file = File::open("tests/complex_player.dat").unwrap();
-    let nbt = nbt::Blob::from_gzip(&mut file).unwrap();
+    let nbt = nbt::Blob::from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        nbt.write(&mut io::sink())
+        nbt.to_writer(&mut io::sink(), Endianness::BigEndian)
     });
 }
 
@@ -148,7 +149,7 @@ fn deserialize_level_as_struct(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        let _: data::Level = from_gzip(&mut src).unwrap();
+        let _: data::Level = from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
@@ -159,24 +160,24 @@ fn deserialize_level_as_blob(b: &mut Bencher) {
     file.read_to_end(&mut contents).unwrap();
     b.iter(|| {
         let mut src = std::io::Cursor::new(&contents[..]);
-        nbt::Blob::from_gzip(&mut src).unwrap();
+        nbt::Blob::from_gzip_reader(&mut src, Endianness::BigEndian).unwrap();
     });
 }
 
 #[bench]
 fn serialize_level_as_struct(b: &mut Bencher) {
     let mut file = File::open("tests/level.dat").unwrap();
-    let nbt: data::Level = from_gzip(&mut file).unwrap();
+    let nbt: data::Level = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        to_writer(&mut io::sink(), &nbt, None)
+        to_writer(&mut io::sink(), &nbt, None, Endianness::BigEndian)
     });
 }
 
 #[bench]
 fn serialize_level_as_blob(b: &mut Bencher) {
     let mut file = File::open("tests/level.dat").unwrap();
-    let nbt = nbt::Blob::from_gzip(&mut file).unwrap();
+    let nbt = nbt::Blob::from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     b.iter(|| {
-        nbt.write(&mut io::sink())
+        nbt.to_writer(&mut io::sink(), Endianness::BigEndian)
     });
 }

--- a/examples/nbtprint.rs
+++ b/examples/nbtprint.rs
@@ -7,13 +7,14 @@ use std::process::exit;
 
 use nbt::Result;
 use nbt::Blob;
+use nbt::Endianness;
 
 fn run() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if let Some(arg) = args.into_iter().skip(1).take(1).next() {
         let mut file = fs::File::open(&arg)?;
         println!("================================= NBT Contents =================================");
-        let blob = Blob::from_reader(&mut file)?;
+        let blob = Blob::from_reader(&mut file, Endianness::BigEndian)?;
         println!("{}", blob);
         println!("============================== JSON Representation =============================");
         match serde_json::to_string_pretty(&blob) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     Serde(String),
     /// An error for when an unknown type ID is encountered in decoding NBT
     /// binary representations. Includes the ID in question.
-    InvalidTypeId(u8),
+    InvalidTypeId(i8),
     /// An error emitted when trying to create `NbtBlob`s with incorrect lists.
     HeterogeneousList,
     /// An error for when NBT binary representations do not begin with an
@@ -39,7 +39,7 @@ pub enum Error {
     IncompleteNbtValue,
     /// An error encountered when parsing NBT binary representations, where
     /// deserialization encounters a different tag than expected.
-    TagMismatch(u8, u8),
+    TagMismatch(i8, i8),
     /// An error encountered when parsing NBT binary representations, where
     /// deserialization encounters a field name it is not expecting.
     UnexpectedField(String),
@@ -93,7 +93,7 @@ impl StdError for Error {
     // enough that we should attempt to support older compilers, especially
     // since we're on the 2015 edition at this time.
     #[allow(deprecated)]
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::IoError(ref e) => e.cause(),
             _ => None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate flate2;
 pub use blob::Blob;
 pub use error::{Error, Result};
 pub use value::Value;
+pub use raw::Endianness;
 
 #[cfg(feature = "serde")]
 #[doc(inline)]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,222 +2,263 @@
 
 use std::io;
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{ReadBytesExt, WriteBytesExt};
 use cesu8::{from_java_cesu8, to_java_cesu8};
 
 use error::{Error, Result};
 
-/// A convenience function for closing NBT format objects.
-///
-/// This function writes a single `0x00` byte to the `io::Write` destination,
-/// which in the NBT format indicates that an open Compound is now closed.
-pub fn close_nbt<W>(dst: &mut W) -> Result<()>
-    where W: io::Write {
-
-    dst.write_u8(0x00).map_err(From::from)
+#[derive(Debug, Clone, Copy)]
+pub enum Endianness {
+    LittleEndian,
+    BigEndian,
 }
 
-#[inline]
-pub fn write_bare_byte<W>(dst: &mut W, value: i8) -> Result<()>
-   where W: io::Write
-{
-    dst.write_i8(value).map_err(From::from)
+pub(crate) struct RawWriter<W: io::Write> {
+    inner: W,
+    endian: Endianness,
 }
 
-#[inline]
-pub fn write_bare_short<W>(dst: &mut W, value: i16) -> Result<()>
-   where W: io::Write
+impl<W> RawWriter<W>
+    where W: io::Write,
 {
-    dst.write_i16::<BigEndian>(value).map_err(From::from)
-}
-
-#[inline]
-pub fn write_bare_int<W>(dst: &mut W, value: i32) -> Result<()>
-   where W: io::Write
-{
-    dst.write_i32::<BigEndian>(value).map_err(From::from)
-}
-
-#[inline]
-pub fn write_bare_long<W>(dst: &mut W, value: i64) -> Result<()>
-   where W: io::Write
-{
-    dst.write_i64::<BigEndian>(value).map_err(From::from)
-}
-
-#[inline]
-pub fn write_bare_float<W>(dst: &mut W, value: f32) -> Result<()>
-   where W: io::Write
-{
-    dst.write_f32::<BigEndian>(value).map_err(From::from)
-}
-
-#[inline]
-pub fn write_bare_double<W>(dst: &mut W, value: f64) -> Result<()>
-   where W: io::Write
-{
-    dst.write_f64::<BigEndian>(value).map_err(From::from)
-}
-
-#[inline]
-pub fn write_bare_byte_array<W>(dst: &mut W, value: &[i8]) -> Result<()>
-   where W: io::Write
-{
-    try!(dst.write_i32::<BigEndian>(value.len() as i32));
-    for &v in value {
-        try!(dst.write_i8(v));
+    pub fn new(inner: W, endian: Endianness) -> Self {
+        RawWriter { inner, endian }
     }
-    Ok(())
-}
 
-#[inline]
-pub fn write_bare_int_array<W>(dst: &mut W, value: &[i32]) -> Result<()>
-   where W: io::Write
-{
-    try!(dst.write_i32::<BigEndian>(value.len() as i32));
-    for &v in value {
-        try!(dst.write_i32::<BigEndian>(v));
+    /// A convenience function for closing NBT format objects.
+    ///
+    /// This function writes a single `0x00` byte to the `io::Write` destination,
+    /// which in the NBT format indicates that an open Compound is now closed.
+    pub fn close_nbt(&mut self) -> Result<()>
+    {
+        self.inner.write_u8(0x00).map_err(From::from)
     }
-    Ok(())
-}
 
-#[inline]
-pub fn write_bare_long_array<W>(dst: &mut W, value: &[i64]) -> Result<()>
-   where W: io::Write
-{
-    dst.write_i32::<BigEndian>(value.len() as i32)?;
-    for &v in value {
-        dst.write_i64::<BigEndian>(v)?;
+    #[inline]
+    pub fn write_bare_byte(&mut self, value: i8) -> Result<()>
+    {
+        self.inner.write_i8(value).map_err(From::from)
     }
-    Ok(())
-}
 
-#[inline]
-pub fn write_bare_string<W>(dst: &mut W, value: &str) -> Result<()>
-   where W: io::Write
-{    
-    let encoded = to_java_cesu8(value);
-    try!(dst.write_u16::<BigEndian>(encoded.len() as u16));
-    dst.write_all(&encoded).map_err(From::from)
-}
-
-/// Extracts the next header (tag and name) from an NBT format source.
-///
-/// This function will also return the `TAG_End` byte and an empty name if it
-/// encounters it.
-pub fn emit_next_header<R>(src: &mut R) -> Result<(u8, String)>
-    where R: io::Read
-{
-    let tag  = try!(src.read_u8());
-
-    match tag {
-        0x00 => { Ok((tag, "".to_string())) },
-        _    => {
-            let name = try!(read_bare_string(src));
-            Ok((tag, name))
-        },
-    }
-}
-
-#[inline]
-pub fn read_bare_byte<R>(src: &mut R) -> Result<i8>
-    where R: io::Read
-{
-    src.read_i8().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_short<R>(src: &mut R) -> Result<i16>
-    where R: io::Read
-{
-    src.read_i16::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_int<R>(src: &mut R) -> Result<i32>
-    where R: io::Read
-{
-    src.read_i32::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_long<R>(src: &mut R) -> Result<i64>
-    where R: io::Read
-{
-    src.read_i64::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_float<R>(src: &mut R) -> Result<f32>
-    where R: io::Read
-{
-    src.read_f32::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_double<R>(src: &mut R) -> Result<f64>
-    where R: io::Read
-{
-    src.read_f64::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_byte_array<R>(src: &mut R) -> Result<Vec<i8>>
-    where R: io::Read
-{
-    // FIXME: Is there a way to return [u8; len]?
-    let len = try!(src.read_i32::<BigEndian>()) as usize;
-    let mut buf = Vec::with_capacity(len);
-    // FIXME: Test performance vs transmute.
-    for _ in 0..len {
-        buf.push(try!(src.read_i8()));
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_int_array<R>(src: &mut R) -> Result<Vec<i32>>
-    where R: io::Read
-{
-    // FIXME: Is there a way to return [i32; len]?
-    let len = try!(src.read_i32::<BigEndian>()) as usize;
-    let mut buf = Vec::with_capacity(len);
-    // FIXME: Test performance vs transmute.
-    for _ in 0..len {
-        buf.push(try!(src.read_i32::<BigEndian>()));
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_long_array<R>(src: &mut R) -> Result<Vec<i64>>
-    where R: io::Read
-{
-    let len = src.read_i32::<BigEndian>()? as usize;
-    let mut buf = Vec::with_capacity(len);
-    for _ in 0..len {
-        buf.push(src.read_i64::<BigEndian>()?);
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_string<R>(src: &mut R) -> Result<String>
-    where R: io::Read
-{
-    let len = try!(src.read_u16::<BigEndian>()) as usize;
-
-    if len == 0 { return Ok("".to_string()); }
-
-    let mut bytes = vec![0; len];
-    let mut n_read = 0usize;
-    while n_read < bytes.len() {
-        match try!(src.read(&mut bytes[n_read..])) {
-            0 => return Err(Error::IncompleteNbtValue),
-            n => n_read += n
+    #[inline]
+    pub fn write_bare_short(&mut self, value: i16) -> Result<()>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.write_i16::<byteorder::LittleEndian>(value).map_err(From::from),
+            Endianness::BigEndian => self.inner.write_i16::<byteorder::BigEndian>(value).map_err(From::from),
         }
     }
 
-    let decoded = from_java_cesu8(&bytes)?;
-    Ok(decoded.into_owned())
+    #[inline]
+    pub fn write_bare_int(&mut self, value: i32) -> Result<()>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.write_i32::<byteorder::LittleEndian>(value).map_err(From::from),
+            Endianness::BigEndian => self.inner.write_i32::<byteorder::BigEndian>(value).map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn write_bare_long(&mut self, value: i64) -> Result<()>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.write_i64::<byteorder::LittleEndian>(value).map_err(From::from),
+            Endianness::BigEndian => self.inner.write_i64::<byteorder::BigEndian>(value).map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn write_bare_float(&mut self, value: f32) -> Result<()>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.write_f32::<byteorder::LittleEndian>(value).map_err(From::from),
+            Endianness::BigEndian => self.inner.write_f32::<byteorder::BigEndian>(value).map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn write_bare_double(&mut self, value: f64) -> Result<()>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.write_f64::<byteorder::LittleEndian>(value).map_err(From::from),
+            Endianness::BigEndian => self.inner.write_f64::<byteorder::BigEndian>(value).map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn write_bare_byte_array(&mut self, value: &[i8]) -> Result<()>
+    {
+        self.write_bare_int(value.len() as i32)?;
+        for &v in value {
+            self.write_bare_byte(v)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn write_bare_int_array(&mut self, value: &[i32]) -> Result<()>
+    {
+        self.write_bare_int(value.len() as i32)?;
+        for &v in value {
+            self.write_bare_int(v)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn write_bare_long_array(&mut self, value: &[i64]) -> Result<()>
+    {
+        self.write_bare_int(value.len() as i32)?;
+        for &v in value {
+            self.write_bare_long(v)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn write_bare_string(&mut self, value: &str) -> Result<()>
+    {
+        let encoded = to_java_cesu8(value);
+        self.write_bare_short(encoded.len() as i16)?;
+        self.inner.write_all(&encoded).map_err(From::from)
+    }
+
+}
+
+pub(crate) struct RawReader<R: io::Read> {
+    inner: R,
+    endian: Endianness,
+}
+
+impl<R> RawReader<R>
+    where R: io::Read,
+{
+    pub fn new(inner: R, endian: Endianness) -> Self {
+        RawReader { inner, endian }
+    }
+
+    /// Extracts the next header (tag and name) from an NBT format source.
+    ///
+    /// This function will also return the `TAG_End` byte and an empty name if it
+    /// encounters it.
+    pub fn emit_next_header(&mut self) -> Result<(i8, String)>
+    {
+        let tag  = self.inner.read_i8()?;
+
+        match tag {
+            0x00 => { Ok((tag, "".to_string())) },
+            _    => {
+                let name = self.read_bare_string()?;
+                Ok((tag, name))
+            },
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_byte(&mut self) -> Result<i8>
+    {
+        self.inner.read_i8().map_err(From::from)
+    }
+
+    #[inline]
+    pub fn read_bare_short(&mut self) -> Result<i16>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.read_i16::<byteorder::LittleEndian>().map_err(From::from),
+            Endianness::BigEndian => self.inner.read_i16::<byteorder::BigEndian>().map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_int(&mut self) -> Result<i32>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.read_i32::<byteorder::LittleEndian>().map_err(From::from),
+            Endianness::BigEndian => self.inner.read_i32::<byteorder::BigEndian>().map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_long(&mut self) -> Result<i64>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.read_i64::<byteorder::LittleEndian>().map_err(From::from),
+            Endianness::BigEndian => self.inner.read_i64::<byteorder::BigEndian>().map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_float(&mut self) -> Result<f32>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.read_f32::<byteorder::LittleEndian>().map_err(From::from),
+            Endianness::BigEndian => self.inner.read_f32::<byteorder::BigEndian>().map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_double(&mut self) -> Result<f64>
+    {
+        match self.endian {
+            Endianness::LittleEndian => self.inner.read_f64::<byteorder::LittleEndian>().map_err(From::from),
+            Endianness::BigEndian => self.inner.read_f64::<byteorder::BigEndian>().map_err(From::from),
+        }
+    }
+
+    #[inline]
+    pub fn read_bare_byte_array(&mut self) -> Result<Vec<i8>>
+    {
+        // FIXME: Is there a way to return [u8; len]?
+        let len = self.read_bare_int()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        // FIXME: Test performance vs transmute.
+        for _ in 0..len {
+            buf.push(self.read_bare_byte()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    pub fn read_bare_int_array(&mut self) -> Result<Vec<i32>>
+    {
+        // FIXME: Is there a way to return [i32; len]?
+        let len = self.read_bare_int()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        // FIXME: Test performance vs transmute.
+        for _ in 0..len {
+            buf.push(self.read_bare_int()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    pub fn read_bare_long_array(&mut self) -> Result<Vec<i64>>
+    {
+        let len = self.read_bare_int()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        for _ in 0..len {
+            buf.push(self.read_bare_long()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    pub fn read_bare_string(&mut self) -> Result<String>
+    {
+        let len = self.read_bare_short()? as usize;
+
+        if len == 0 { return Ok("".to_string()); }
+
+        let mut bytes = vec![0; len];
+        let mut n_read = 0usize;
+        while n_read < bytes.len() {
+            match self.inner.read(&mut bytes[n_read..])? {
+                0 => return Err(Error::IncompleteNbtValue),
+                n => n_read += n
+            }
+        }
+
+        let decoded = from_java_cesu8(&bytes)?;
+        Ok(decoded.into_owned())
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 
 //use test::Bencher;
 
+use raw::Endianness;
 use blob::Blob;
 use error::Error;
 use value::Value;
@@ -46,14 +47,14 @@ fn nbt_nonempty() {
 
     // Test correct length.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(bytes.len(), dst.len());
 
     // We can only test if the decoded bytes match, since the HashMap does
     // not guarantee order (and so encoding is likely to be different, but
     // still correct).
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }
 
@@ -69,12 +70,12 @@ fn nbt_empty_nbtfile() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }
 
@@ -101,12 +102,12 @@ fn nbt_nested_compound() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }
 
@@ -128,12 +129,12 @@ fn nbt_empty_list() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }
 
@@ -164,12 +165,12 @@ fn nbt_nested_list() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }
 
@@ -177,7 +178,7 @@ fn nbt_nested_list() {
 fn nbt_no_root() {
     let bytes = vec![0x00];
     // Will fail, because the root is not a compound.
-    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..])),
+    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..]), Endianness::BigEndian),
             Err(Error::NoRootCompound));
 }
 
@@ -194,7 +195,7 @@ fn nbt_no_end_tag() {
     ];
 
     // Will fail, because there is no end tag.
-    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..])),
+    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..]), Endianness::BigEndian),
             Err(Error::IncompleteNbtValue));
 }
 
@@ -209,7 +210,7 @@ fn nbt_invalid_id() {
                 0x01,
         0x00
     ];
-    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..])),
+    assert_eq!(Blob::from_reader(&mut io::Cursor::new(&bytes[..]), Endianness::BigEndian),
                Err(Error::InvalidTypeId(15)));
 }
 
@@ -228,8 +229,8 @@ fn nbt_invalid_list() {
 fn nbt_bad_compression() {
     // These aren't in the zlib or gzip format, so they'll fail.
     let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    assert!(Blob::from_gzip_reader(&mut io::Cursor::new(&bytes[..])).is_err());
-    assert!(Blob::from_zlib_reader(&mut io::Cursor::new(&bytes[..])).is_err());
+    assert!(Blob::from_gzip_reader(&mut io::Cursor::new(&bytes[..]), Endianness::BigEndian).is_err());
+    assert!(Blob::from_zlib_reader(&mut io::Cursor::new(&bytes[..]), Endianness::BigEndian).is_err());
 }
 
 #[test]
@@ -244,31 +245,31 @@ fn nbt_compression() {
 
     // Test zlib encoding/decoding.
     let mut zlib_dst = Vec::new();
-    nbt.to_zlib_writer(&mut zlib_dst).unwrap();
-    let zlib_file = Blob::from_zlib_reader(&mut io::Cursor::new(zlib_dst)).unwrap();
+    nbt.to_zlib_writer(&mut zlib_dst, Endianness::BigEndian).unwrap();
+    let zlib_file = Blob::from_zlib_reader(&mut io::Cursor::new(zlib_dst), Endianness::BigEndian).unwrap();
     assert_eq!(&nbt, &zlib_file);
 
     // Test gzip encoding/decoding.
     let mut gzip_dst = Vec::new();
-    nbt.to_gzip_writer(&mut gzip_dst).unwrap();
-    let gz_file = Blob::from_gzip_reader(&mut io::Cursor::new(gzip_dst)).unwrap();
+    nbt.to_gzip_writer(&mut gzip_dst, Endianness::BigEndian).unwrap();
+    let gz_file = Blob::from_gzip_reader(&mut io::Cursor::new(gzip_dst), Endianness::BigEndian).unwrap();
     assert_eq!(&nbt, &gz_file);
 }
 
 #[test]
 fn nbt_bigtest() {
     let mut bigtest_file = File::open("tests/big1.nbt").unwrap();
-    let bigtest = Blob::from_gzip_reader(&mut bigtest_file).unwrap();
+    let bigtest = Blob::from_gzip_reader(&mut bigtest_file, Endianness::BigEndian).unwrap();
     // This is a pretty indirect way of testing correctness.
     let mut dst = Vec::new();
-    bigtest.to_writer(&mut dst).unwrap();
+    bigtest.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(1544, dst.len());
 }
 
 #[test]
 fn nbt_arrays() {
     let mut arrays_file = File::open("tests/arrays.nbt").unwrap();
-    let arrays = Blob::from_reader(&mut arrays_file).unwrap();
+    let arrays = Blob::from_reader(&mut arrays_file, Endianness::BigEndian).unwrap();
     match &arrays["ia"] {
         &Value::IntArray(ref arr) => assert_eq!(&[-2, -1, 0, 1, 2], &**arr),
         _ => panic!("ia was not TAG_IntArray"),
@@ -328,10 +329,10 @@ fn serde_blob() {
     // Roundtrip.
 
     let mut src = io::Cursor::new(bytes.clone());
-    let file: Blob = from_reader(&mut src).unwrap();
+    let file: Blob = from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
     let mut dst = Vec::new();
-    to_writer(&mut dst, &nbt, None).unwrap();
+    to_writer(&mut dst, &nbt, None, Endianness::BigEndian).unwrap();
     // We can only test if the decoded bytes match, since the HashMap does
     // not guarantee order (and so encoding is likely to be different, but
     // still correct).
@@ -357,11 +358,11 @@ fn nbt_modified_utf8() {
 
     // Test encoding.
     let mut dst = Vec::new();
-    nbt.to_writer(&mut dst).unwrap();
+    nbt.to_writer(&mut dst, Endianness::BigEndian).unwrap();
     assert_eq!(&dst, &bytes);
 
     // Test decoding.
     let mut src = io::Cursor::new(bytes);
-    let file = Blob::from_reader(&mut src).unwrap();
+    let file = Blob::from_reader(&mut src, Endianness::BigEndian).unwrap();
     assert_eq!(&file, &nbt);
 }

--- a/tests/data.rs.in
+++ b/tests/data.rs.in
@@ -67,7 +67,7 @@ pub struct Big1 {
     #[serde(rename = "longTest")] long_test: i64,
     #[serde(rename = "shortTest")] short_test: i32,
     #[serde(rename = "byteTest")] byte_test: i8,
-    #[serde(rename = "floatTest")] float_test: i64,
+    #[serde(rename = "floatTest")] float_test: f32,
     #[serde(rename = "nested compound test")] nested_compound_test: Big1Sub3,
     #[serde(rename = "byteArrayTest (the first 1000 values of (n*n*255+n*7)%100, starting with n=0 (0, 62, 34, 16, 8, ...))")]
     byte_array_test: Vec<i8>, // [i8; 1000] does not implement PartialEq.

--- a/tests/filetests.rs
+++ b/tests/filetests.rs
@@ -10,6 +10,7 @@ extern crate nbt;
 use std::fs::File;
 
 use nbt::de::{from_reader, from_gzip_reader};
+use nbt::Endianness;
 
 // Include structure definitions.
 include!("data.rs.in");
@@ -18,7 +19,7 @@ include!("data.rs.in");
 fn deserialize_small1() {
     let nbt = Small1 { name: "Bananrama".to_string() };
     let mut file = File::open("tests/small1.nbt").unwrap();
-    let read: Small1 = from_reader(&mut file).unwrap();
+    let read: Small1 = from_reader(&mut file, Endianness::BigEndian).unwrap();
     assert_eq!(nbt, read)
 }
 
@@ -29,7 +30,7 @@ fn deserialize_small2() {
         bbb: Small2Sub { one: 17, two: 4386, three: 287454020 }
     };
     let mut file = File::open("tests/small2.nbt").unwrap();
-    let read: Small2 = from_reader(&mut file).unwrap();
+    let read: Small2 = from_reader(&mut file, Endianness::BigEndian).unwrap();
     assert_eq!(nbt, read)
 }
 
@@ -42,7 +43,7 @@ fn deserialize_small3() {
         ]
     };
     let mut file = File::open("tests/small3.nbt").unwrap();
-    let read: Small3 = from_reader(&mut file).unwrap();
+    let read: Small3 = from_reader(&mut file, Endianness::BigEndian).unwrap();
     assert_eq!(nbt, read)
 }
 
@@ -53,7 +54,7 @@ fn deserialize_small4() {
         c2: Small4Sub { aaa: 17, bbb: 34, ccc: 51, ddd: 68 }
     };
     let mut file = File::open("tests/small4.nbt").unwrap();
-    let read: Small4 = from_reader(&mut file).unwrap();
+    let read: Small4 = from_reader(&mut file, Endianness::BigEndian).unwrap();
     assert_eq!(nbt, read)
 }
 
@@ -70,7 +71,7 @@ fn deserialize_big1() {
         long_test: 9223372036854775807,
         short_test: 32767,
         byte_test: 127,
-        float_test: 0,
+        float_test: 0.0,
         nested_compound_test: Big1Sub3 {
             ham: Big1Sub2 { name: "Hampus".to_string(), value: 0.75 },
             egg: Big1Sub2 { name: "Eggbert".to_string(), value: 0.5 }
@@ -161,24 +162,24 @@ fn deserialize_big1() {
         int_test: 2147483647,
     };
     let mut file = File::open("tests/big1.nbt").unwrap();
-    let read: Big1 = from_gzip_reader(&mut file).unwrap();
+    let read: Big1 = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
     assert_eq!(nbt, read)
 }
 
 #[test]
 fn deserialize_simple_player() {
     let mut file = File::open("tests/simple_player.dat").unwrap();
-    let _: PlayerData = from_gzip_reader(&mut file).unwrap();
+    let _: PlayerData = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
 }
 
 #[test]
 fn deserialize_complex_player() {
     let mut file = File::open("tests/complex_player.dat").unwrap();
-    let _: PlayerData = from_gzip_reader(&mut file).unwrap();
+    let _: PlayerData = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
 }
 
 #[test]
 fn deserialize_level() {
     let mut file = File::open("tests/level.dat").unwrap();
-    let _: Level = from_gzip_reader(&mut file).unwrap();
+    let _: Level = from_gzip_reader(&mut file, Endianness::BigEndian).unwrap();
 }

--- a/tests/serde_basics.rs
+++ b/tests/serde_basics.rs
@@ -7,6 +7,7 @@ extern crate nbt;
 use std::collections::HashMap;
 
 use nbt::de::from_reader;
+use nbt::Endianness;
 
 /// Helper function that asserts data of type T can be serialized into and
 /// deserialized from `bytes`. `name` is an optional header for the top-level
@@ -16,10 +17,10 @@ where for <'de> T: serde::Serialize + serde::Deserialize<'de> + PartialEq + std:
 {
     let mut dst = Vec::with_capacity(bytes.len());
 
-    nbt::ser::to_writer(&mut dst, &nbt, name).expect("NBT serialization.");
+    nbt::ser::to_writer(&mut dst, &nbt, name, Endianness::BigEndian).expect("NBT serialization.");
     assert_eq!(bytes, &dst[..]);
 
-    let read: T = nbt::de::from_reader(bytes).expect("NBT deserialization.");
+    let read: T = nbt::de::from_reader(bytes, Endianness::BigEndian).expect("NBT deserialization.");
     assert_eq!(read, nbt);
 }
 
@@ -191,7 +192,7 @@ fn deserialize_nested_array() {
         0x00
     ];
 
-    let read: NestedArrayNbt = from_reader(&bytes[..]).unwrap();
+    let read: NestedArrayNbt = from_reader(&bytes[..], Endianness::BigEndian).unwrap();
     assert_eq!(read, nbt)
 }
 
@@ -210,7 +211,7 @@ fn deserialize_byte_array() {
         0x00
     ];
 
-    let read: BasicListNbt = from_reader(&bytes[..]).unwrap();
+    let read: BasicListNbt = from_reader(&bytes[..], Endianness::BigEndian).unwrap();
     assert_eq!(read, nbt)
 }
 
@@ -233,7 +234,7 @@ fn deserialize_empty_array() {
         0x00
     ];
 
-    let read: IntListNbt = from_reader(&bytes[..]).unwrap();
+    let read: IntListNbt = from_reader(&bytes[..], Endianness::BigEndian).unwrap();
     assert_eq!(read, nbt)
 }
 
@@ -255,7 +256,7 @@ fn deserialize_int_array() {
         0x00
     ];
 
-    let read: IntListNbt = from_reader(&bytes[..]).unwrap();
+    let read: IntListNbt = from_reader(&bytes[..], Endianness::BigEndian).unwrap();
     assert_eq!(read, nbt)
 }
 
@@ -282,7 +283,7 @@ fn deserialize_long_array() {
         0x00
     ];
 
-    let read: LongListNbt = from_reader(&bytes[..]).unwrap();
+    let read: LongListNbt = from_reader(&bytes[..], Endianness::BigEndian).unwrap();
     assert_eq!(read, nbt)
 }
 

--- a/tests/serde_errors.rs
+++ b/tests/serde_errors.rs
@@ -7,13 +7,14 @@ extern crate nbt;
 use nbt::de::from_reader;
 use nbt::ser::to_writer;
 use nbt::{Error, Result};
+use nbt::Endianness;
 
 #[test]
 fn no_root_compound() {
     let nbt: i8 = 100;
 
     let mut dst = Vec::new();
-    let write = to_writer(&mut dst, &nbt, None);
+    let write = to_writer(&mut dst, &nbt, None, Endianness::BigEndian);
 
     assert!(write.is_err());
     match write.unwrap_err() {
@@ -38,7 +39,7 @@ fn incomplete_nbt() {
                 0x01
     ];
 
-    let read: Result<ByteNbt> = from_reader(&bytes[..]);
+    let read: Result<ByteNbt> = from_reader(&bytes[..], Endianness::BigEndian);
 
     assert!(read.is_err());
     match read.unwrap_err() {
@@ -59,7 +60,7 @@ fn unknown_tag() {
         0x00
     ];
 
-    let read: Result<ByteNbt> = from_reader(&bytes[..]);
+    let read: Result<ByteNbt> = from_reader(&bytes[..], Endianness::BigEndian);
 
     assert!(read.is_err());
     match read.unwrap_err() {
@@ -80,7 +81,7 @@ fn deserialized_wrong_type() {
         0x00
     ];
 
-    let read: Result<ByteNbt> = from_reader(&bytes[..]);
+    let read: Result<ByteNbt> = from_reader(&bytes[..], Endianness::BigEndian);
 
     assert!(read.is_err());
     match read.unwrap_err() {
@@ -107,7 +108,7 @@ fn non_boolean_byte() {
         0x00
     ];
 
-    let read: Result<BoolNbt> = from_reader(&bytes[..]);
+    let read: Result<BoolNbt> = from_reader(&bytes[..], Endianness::BigEndian);
 
     assert!(read.is_err());
     match read.unwrap_err() {


### PR DESCRIPTION
This pull request adds support for little-endian encoding, which is what Bedrock Edition uses for encoding NBT data. The encoding (i.e., big endian or little endian) is determined by a parameter passed to the serialization/deserialization functions at runtime. 

Initially, I implemented it differently, by having the encoding be a compile-time type parameter (making functions generic over <B: ByteOrder>), but this led to a proliferation of type parameters, and would essentially lead to two copies of the library being generated during monomorphization. Therefore, I thought the runtime encoding selection makes the most sense.

I also fixed the tests and benchmarks, but didn't add any new tests/documentation yet. I would be glad to hear if you have any comments or suggestions about my approach and implementation.