### PR TITLE
Fix UnrepresentableType error message

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -169,6 +169,6 @@ macro_rules! return_expr_for_serialized_types {
 
 macro_rules! unrepresentable {
     ($($type:tt)*) => {
-        $(return_expr_for_serialized_types_helper!{Err(Error::UnrepresentableType("$type")), $type})*
+        $(return_expr_for_serialized_types_helper!{Err(Error::UnrepresentableType(stringify!($type))), $type})*
     };
 }


### PR DESCRIPTION
The current implementation of the `unrepresentable` macro attempts to pass `$type`
as the message for the `UnrepresentableType` error. However, macro parameters
are not expanded inside string literals, so the error message appeared as "$type" instead
of "u8" or "u16." The bug was fixed using the `stringify` macro.