### PR TITLE
Add calculation of serialized size

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -153,7 +153,7 @@ impl Blob {
     }
 
     /// The number of bytes this blob will serialize to, before compression
-    pub fn serialized_size(&self) -> usize 
+    pub fn len_bytes(&self) -> usize 
     {
         1 /* compound tag */ 
         + 2 /* name length*/ 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -151,6 +151,16 @@ impl Blob {
     {
         self.content.get(name.into())
     }
+
+    /// The number of bytes this blob will serialize to, before compression
+    pub fn serialized_size(&self) -> usize 
+    {
+        1 /* compound tag */ 
+        + 2 /* name length*/ 
+        + self.title.len() 
+        + self.content.iter().map(Value::size_of_compound_entry).sum::<usize>() 
+        + 1 /* TAG_END */
+    }
 }
 
 impl<'a> Index<&'a str> for Blob {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -365,3 +365,43 @@ fn nbt_modified_utf8() {
     let file = Blob::from_reader(&mut src).unwrap();
     assert_eq!(&file, &nbt);
 }
+
+#[test]
+fn nbt_sizes() {
+    // Arbitarary values, covering most data types
+    let mut subtree = HashMap::<String, Value>::new();
+    subtree.insert("name".into(), "Herobrine".into());
+    subtree.insert("health".into(), 100i8.into());
+    subtree.insert("enormous".into(), 100i64.into());
+    subtree.insert("food".into(), 20.0f32.into());
+    subtree.insert("emeralds".into(), 12345i16.into());
+    subtree.insert("timestamp".into(), 1424778774i32.into());
+    subtree.insert("list".into(), Value::List(vec![1,2,3,4].into_iter().map(Value::Int).collect()));
+
+    let deeper_sub = Value::Compound(subtree.clone());
+
+    subtree.insert("recursion".into(), deeper_sub);
+
+    let subling_sub = Value::Compound(subtree.clone());
+    let orig_compound = Value::Compound(subtree);
+
+    // Here so this test covers every tag type
+    let byte_array = Value::ByteArray((-127..127).collect());
+    let int_array = Value::IntArray((0..128).collect());
+    let long_array = Value::LongArray((0..512).collect());
+
+    // Creating a blob that has weird nested compounds/lists/arrays
+    // Intended to cover all possible tags and make sure recursions 
+    // handle nested types correctly.
+    let mut root = Blob::new();
+    root.insert("List-C", Value::List(vec![orig_compound,subling_sub])).unwrap();
+    root.insert("List-B", byte_array).unwrap();
+    root.insert("List-I", int_array).unwrap();
+    root.insert("List-L", long_array).unwrap();
+
+    // Write out the blob
+    let mut cursor = std::io::Cursor::new(vec![]);
+    root.to_writer(&mut cursor).unwrap();
+
+    assert_eq!(cursor.position() as usize, root.serialized_size());
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -403,5 +403,5 @@ fn nbt_sizes() {
     let mut cursor = std::io::Cursor::new(vec![]);
     root.to_writer(&mut cursor).unwrap();
 
-    assert_eq!(cursor.position() as usize, root.serialized_size());
+    assert_eq!(cursor.position() as usize, root.len_bytes());
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -192,20 +192,20 @@ impl Value {
     }
 
     /// The number of bytes this value serializes to, before compression
-    pub fn serialized_size(&self) -> usize {
-        1 /* type ID */ + self.uncompressed_size_of_payload()
+    pub fn len_bytes(&self) -> usize {
+        1 /* type ID */ + self.len_payload()
     }
 
     /// Serialized size of an entry within a TAG_COMPOUND
     /// Also used by Blob, so crate visible
     pub(crate) fn size_of_compound_entry((key, value): (&String, &Value)) -> usize {
         let key_len = 2 + key.len();
-        let value_len = value.serialized_size();
+        let value_len = value.len_bytes();
         key_len + value_len
     }
 
     // The serialized size of the payload specifically, without tag IDs or names prepended.
-    fn uncompressed_size_of_payload(&self) -> usize {
+    fn len_payload(&self) -> usize {
         use std::mem::size_of;
         match self {
             Value::Byte(_)   => 1,
@@ -216,7 +216,7 @@ impl Value {
             Value::Double(_) => 8,
             Value::String(s) => 2 /* string size */ + s.len(),
             Value::List(v) => {
-                1 /* item tag */ + 4 /* arr size */ + v.iter().map(Self::uncompressed_size_of_payload).sum::<usize>()
+                1 /* item tag */ + 4 /* arr size */ + v.iter().map(Self::len_payload).sum::<usize>()
             }
             Value::Compound(hm) => {
                 hm.iter().map(Self::size_of_compound_entry).sum::<usize>() + 1usize /* TAG_END */


### PR DESCRIPTION
I'm working on a server project that relies on this crate to handle NBT fields in the network protocol. To write out packets efficiently, it relies on being able to tell how long each data item will be before serialization begins, but there didn't seem to be a way to do that for NBT values with their existing API. (Beyond extracting sub-values and manually calculating it) 

Since other people are likely to need this functionality, I thought I'd submit it as a PR. (I've not made any style changes or warning fixes in other code)

Specifically, the public API addition is that `Value` and `Blob` now have a `serialized_size` method that reports the number of bytes they will serialize into, without any compression. There is also a new test in `tests.rs` that constructs a Blob with at least one field of each existing tag, and asserts that the reported serialized size matches the length of the actual serialization output. 

Hope this is useful to you, let me know if you'd like any changes. 