### PR TITLE
Serde byte/int/long array serialization (Issue  #27 / #32)

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -350,18 +350,18 @@ impl<'a, 'b, W> serde::Serializer for &'a mut InnerEncoder<'a, 'b, W> where W: i
     }
 }
 
-/// A serializer for valid map keys, i.e. strings.
-struct MapKeyEncoder<'a, 'b: 'a, W: 'a> {
+/// A serializer for valid tag names, i.e. strings.
+struct TagNameEncoder<'a, 'b: 'a, W: 'a> {
     outer: &'a mut Encoder<'b, W>,
 }
 
-impl<'a, 'b: 'a, W: 'a> MapKeyEncoder<'a, 'b, W> where W: io::Write {
+impl<'a, 'b: 'a, W: 'a> TagNameEncoder<'a, 'b, W> where W: io::Write {
     pub fn from_outer(outer: &'a mut Encoder<'b, W>) -> Self {
-        MapKeyEncoder { outer: outer }
+        TagNameEncoder { outer: outer }
     }
 }
 
-impl<'a, 'b: 'a, W: 'a> serde::Serializer for &'a mut MapKeyEncoder<'a, 'b, W>
+impl<'a, 'b: 'a, W: 'a> serde::Serializer for &'a mut TagNameEncoder<'a, 'b, W>
     where W: io::Write
 {
     type Ok = ();
@@ -395,7 +395,7 @@ impl<'a, 'b: 'a, W: 'a> serde::Serializer for &'a mut MapKeyEncoder<'a, 'b, W>
     }
 }
 
-/// A serializer for valid map keys.
+/// A serializer for valid tags.
 struct TagEncoder<'a, 'b: 'a, W: 'a, K> {
     outer: &'a mut Encoder<'b, W>,
     key: Option<&'a K>,
@@ -434,7 +434,7 @@ where W: io::Write,
         };
 
         raw::write_bare_byte(&mut self.outer.writer, tag)?;
-        self.key.serialize(&mut MapKeyEncoder::from_outer(self.outer))?;
+        self.key.serialize(&mut TagNameEncoder::from_outer(self.outer))?;
 
         Ok(())
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -443,8 +443,6 @@ where W: io::Write,
     }
 
     fn write_header(&mut self, tag: i8) -> Result<()> {
-        use serde::Serialize;
-
         let tag = match self.tag_type {
             TagType::Normal( .. ) => tag,
             TagType::SeqTag( .. ) => match tag {

--- a/tests/serde_basics.rs
+++ b/tests/serde_basics.rs
@@ -169,7 +169,7 @@ struct NestedArrayNbt {
 }
 
 #[test]
-fn deserialize_nested_array() {
+fn roundtrip_nested_array() {
     let nbt = NestedArrayNbt { data: vec!(vec!(1, 2), vec!(3, 4)) };
 
     let bytes = vec![
@@ -191,13 +191,17 @@ fn deserialize_nested_array() {
         0x00
     ];
 
-    let read: NestedArrayNbt = from_reader(&bytes[..]).unwrap();
-    assert_eq!(read, nbt)
+    assert_roundtrip_eq(nbt, &bytes, None);
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ByteArrayNbt {
+    data: Vec<i8>,
 }
 
 #[test]
-fn deserialize_byte_array() {
-    let nbt = BasicListNbt { data: vec![1, 2, 3] };
+fn roundtrip_byte_array() {
+    let nbt = ByteArrayNbt { data: vec![1, 2, 3] };
 
     let bytes = vec![
         0x0a,
@@ -210,8 +214,7 @@ fn deserialize_byte_array() {
         0x00
     ];
 
-    let read: BasicListNbt = from_reader(&bytes[..]).unwrap();
-    assert_eq!(read, nbt)
+    assert_roundtrip_eq(nbt, &bytes, None);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -238,7 +241,7 @@ fn deserialize_empty_array() {
 }
 
 #[test]
-fn deserialize_int_array() {
+fn roundtrip_int_array() {
     let nbt = IntListNbt { data: vec![1, 2, 3] };
 
     let bytes = vec![
@@ -255,8 +258,7 @@ fn deserialize_int_array() {
         0x00
     ];
 
-    let read: IntListNbt = from_reader(&bytes[..]).unwrap();
-    assert_eq!(read, nbt)
+    assert_roundtrip_eq(nbt, &bytes, None);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -265,7 +267,7 @@ struct LongListNbt {
 }
 
 #[test]
-fn deserialize_long_array() {
+fn roundtrip_long_array() {
     let nbt = LongListNbt { data: vec![1, 2, 3] };
 
     let bytes = vec![
@@ -282,8 +284,7 @@ fn deserialize_long_array() {
         0x00
     ];
 
-    let read: LongListNbt = from_reader(&bytes[..]).unwrap();
-    assert_eq!(read, nbt)
+    assert_roundtrip_eq(nbt, &bytes, None);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR aims to implement serde serialization support to serialize i8, i32 and i64 sequence types to NBT ByteArray, IntegerArray and LongArray respectively.
This implementation checks the type of the first sequence element to determine which NBT List/Array type to use.
This means of course that serializing to a NBT List of NBT Byte/Integer/Long types is not possible anymore, but as discussed in #27 this doesn't seem to be used in practice. Also if required this could probably be implemented as some kind of option later.

I ran some rudimentary tests by serializing a Minecraft chunk with https://github.com/feather-rs/feather including Lists and LongArrays and checking the result in an NBT viewer. Everything serialized as expected.

This would resolve #27 and #32.