### PR TITLE
Explicit array serialization in serde

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub use value::Value;
 pub use de::{from_gzip_reader, from_reader, from_zlib_reader};
 #[cfg(feature = "serde")]
 #[doc(inline)]
+pub use ser::{i32_array, i64_array, i8_array};
+#[cfg(feature = "serde")]
+#[doc(inline)]
 pub use ser::{to_gzip_writer, to_writer, to_zlib_writer};
 
 mod blob;


### PR DESCRIPTION
This PR aims to implement Byte/Int/Long array serialization support for serde.
Right now every `Vec<i8>` or similar sequence types get serialized to a `List` of `Byte`s instead of the `ByteArray` type. This PR implements a serde `serialize_with` function to tag fields of collection types to serialize into `ByteArray`/`IntArray`/`LongArray` (called `i8_array`/`i32_array`/`i64_array` respectively).

For example:
```
#[derive(Serialize)]
struct MyStruct {
    #[serde(serialize_with="hematite_nbt::i8_array")]
    byte_array: Vec<i8>,
}
```
This will serialize to a compound containing a `ByteArray` instead of a `List` of `Byte`s.

## Current limitations
- As this approach uses a bit of a hack internally because of serde limitations, fields tagged to use the array serializer can **only** be serialized with `hematite-nbt`. When serializing with a different serializer this will try to serialize as a `serde` `tuple_struct` with the name `__hematite_nbt_i8_array__` (or `i32`/`i64` respectively) and the array elements as fields of that tuple.
- Serde currently doesn't support using `serialize_with` on inner elements (of `Option`, `Vec`, ...) and thus nested arrays are not trivially supported (see https://github.com/serde-rs/serde/issues/723). A workaround for this as also currently used in `hematite_nbt` tests is not _that_ clean, but it can be made to work:
    ```
    #[derive(Debug, PartialEq, Serialize, Deserialize)]
    struct NestedArrayNbt {
        #[serde(serialize_with = "nested_i32_array")]
        data: Vec<Vec<i32>>,
    }

    fn nested_i32_array<S>(outer_arr: &Vec<Vec<i32>>, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: Serializer,
    {
        #[derive(Debug, Serialize)]
        struct Wrapper(#[serde(serialize_with = "nbt::i32_array")] Vec<i32>);

        // clone should be optimized to a no-op
        serializer.collect_seq(outer_arr.iter().map(|vec| Wrapper(vec.clone())))
    }
    ```
---
More details and discussion can also be found in the PR of a previous, different approach on implicitely converting all NBT lists that can be represented as arrays: #51

Resolves #27 
Resolves #32 