### PR TITLE
Enable use of custom serde serializer on nbt arrays

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -715,10 +715,10 @@ impl ser::SerializeMap for NoOp {
 ///
 /// print!("Serialized: {:?}", serialized);
 /// ```
-pub fn i8_array<'a, T, S>(array: &'a T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+pub fn i8_array<T, S>(array: T, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
-    &'a T: IntoIterator,
-    <&'a T as IntoIterator>::Item: std::borrow::Borrow<i8>,
+    T: IntoIterator,
+    <T as IntoIterator>::Item: std::borrow::Borrow<i8>,
     S: serde::ser::Serializer,
 {
     array_serializer!("i8_array", array, serializer)
@@ -755,10 +755,10 @@ where
 ///
 /// print!("Serialized: {:?}", serialized);
 /// ```
-pub fn i32_array<'a, T, S>(array: &'a T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+pub fn i32_array<T, S>(array: T, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
-    &'a T: IntoIterator,
-    <&'a T as IntoIterator>::Item: std::borrow::Borrow<i32>,
+    T: IntoIterator,
+    <T as IntoIterator>::Item: std::borrow::Borrow<i32>,
     S: serde::ser::Serializer,
 {
     array_serializer!("i32_array", array, serializer)
@@ -795,10 +795,10 @@ where
 ///
 /// print!("Serialized: {:?}", serialized);
 /// ```
-pub fn i64_array<'a, T, S>(array: &'a T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+pub fn i64_array<T, S>(array: T, serializer: S) -> std::result::Result<S::Ok, S::Error>
 where
-    &'a T: IntoIterator,
-    <&'a T as IntoIterator>::Item: std::borrow::Borrow<i64>,
+    T: IntoIterator,
+    <T as IntoIterator>::Item: std::borrow::Borrow<i64>,
     S: serde::ser::Serializer,
 {
     array_serializer!("i64_array", array, serializer)


### PR DESCRIPTION
Because of a little oversight on my part when implementing the `ser::ixx_array` functions they currently take a `&'a T: IntoIterator` as their array reference parameter, which is only ever used for a call of `.into_iterator` on the passed argument. Thus the trait bound can be simplified to `T: IntoIterator` which would allow `ser::ixx_array` to be called manually (i.e. from a custom `with_serializer` implementation) with an iterator as the array reference parameter to manipulate the array values before serialization as used in the correspondingly implemented `serialize_custom_serializer_array` test.
This PR also rewrites parts of the `roundtrip_nested_array` test to make sure that no unnecessary memory allocation occurs on serialization.