### PR TITLE
Preserve order of compound fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ authors = [
 
 [features]
 default = ["serde"]
+preserve_order = ["indexmap"]
 
 [lib]
 name = "nbt"
@@ -25,6 +26,7 @@ bench = false
 byteorder = "1.0.0"
 cesu8 = "1.1.0"
 flate2 = "0.2"
+indexmap = { version = "1.4", optional = true, features = ["serde-1"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::Map;
 use std::fmt;
 use std::io;
 use std::ops::Index;
@@ -38,7 +38,7 @@ use value::Value;
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Blob {
     title: String,
-    content: HashMap<String, Value>,
+    content: Map<String, Value>,
 }
 
 impl Blob {
@@ -46,7 +46,7 @@ impl Blob {
     pub fn new() -> Blob {
         Blob {
             title: "".to_string(),
-            content: HashMap::new(),
+            content: Map::new(),
         }
     }
 
@@ -57,7 +57,7 @@ impl Blob {
     {
         Blob {
             title: name.into(),
-            content: HashMap::new(),
+            content: Map::new(),
         }
     }
 
@@ -138,7 +138,7 @@ impl Blob {
     }
 
     /// Insert an `Value` with a given name into this `Blob` object. This
-    /// method is just a thin wrapper around the underlying `HashMap` method of
+    /// method is just a thin wrapper around the underlying map method of
     /// the same name.
     ///
     /// This method will also return an error if a `Value::List` with
@@ -236,7 +236,7 @@ impl<'de> serde::Deserialize<'de> for Blob {
         D: serde::de::Deserializer<'de>,
     {
         // No support for named Blobs.
-        let map: HashMap<String, Value> = serde::de::Deserialize::deserialize(deserializer)?;
+        let map: Map<String, Value> = serde::de::Deserialize::deserialize(deserializer)?;
         Ok(Blob {
             title: "".to_string(),
             content: map,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,13 @@ pub use blob::Blob;
 pub use error::{Error, Result};
 pub use value::Value;
 
+#[cfg(feature = "preserve_order")]
+extern crate indexmap;
+#[cfg(feature = "preserve_order")]
+pub use indexmap::IndexMap as Map;
+#[cfg(not(feature = "preserve_order"))]
+pub use std::collections::HashMap as Map;
+
 #[cfg(feature = "serde")]
 #[doc(inline)]
 pub use de::{from_gzip_reader, from_reader, from_zlib_reader};

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::Map;
 use std::fmt;
 use std::io;
 
@@ -22,7 +22,7 @@ pub enum Value {
     ByteArray(Vec<i8>),
     String(String),
     List(Vec<Value>),
-    Compound(HashMap<String, Value>),
+    Compound(Map<String, Value>),
     IntArray(Vec<i32>),
     LongArray(Vec<i64>),
 }
@@ -141,7 +141,7 @@ impl Value {
             }
             0x0a => {
                 // Compound
-                let mut buf = HashMap::new();
+                let mut buf = Map::new();
                 loop {
                     let (id, name) = raw::emit_next_header(src)?;
                     if id == 0x00 {


### PR DESCRIPTION
Keeps the order of compound fields as they are declared in the loaded file using `indexmap`.

Closes #42 