### PR TITLE
Upgrade flate2 to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bench = false
 [dependencies]
 byteorder = "1.0.0"
 cesu8 = "1.1.0"
-flate2 = "0.2"
+flate2 = "1.0.16"
 indexmap = { version = "1.4", optional = true, features = ["serde-1"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -90,7 +90,7 @@ impl Blob {
         R: io::Read,
     {
         // Reads the gzip header, and fails if it is incorrect.
-        let mut data = GzDecoder::new(src)?;
+        let mut data = GzDecoder::new(src);
         Blob::from_reader(&mut data)
     }
 
@@ -125,7 +125,7 @@ impl Blob {
     where
         W: io::Write,
     {
-        self.to_writer(&mut GzEncoder::new(dst, Compression::Default))
+        self.to_writer(&mut GzEncoder::new(dst, Compression::default()))
     }
 
     /// Writes the binary representation of this `Blob`, compressed using
@@ -134,7 +134,7 @@ impl Blob {
     where
         W: io::Write,
     {
-        self.to_writer(&mut ZlibEncoder::new(dst, Compression::Default))
+        self.to_writer(&mut ZlibEncoder::new(dst, Compression::default()))
     }
 
     /// Insert an `Value` with a given name into this `Blob` object. This

--- a/src/de.rs
+++ b/src/de.rs
@@ -31,7 +31,7 @@ where
     R: io::Read,
     T: de::DeserializeOwned,
 {
-    let gzip = read::GzDecoder::new(src)?;
+    let gzip = read::GzDecoder::new(src);
     from_reader(gzip)
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -31,7 +31,7 @@ where
     W: ?Sized + io::Write,
     T: ?Sized + ser::Serialize,
 {
-    let mut encoder = Encoder::new(GzEncoder::new(dst, Compression::Default), header);
+    let mut encoder = Encoder::new(GzEncoder::new(dst, Compression::default()), header);
     value.serialize(&mut encoder)
 }
 
@@ -42,7 +42,7 @@ where
     W: ?Sized + io::Write,
     T: ?Sized + ser::Serialize,
 {
-    let mut encoder = Encoder::new(ZlibEncoder::new(dst, Compression::Default), header);
+    let mut encoder = Encoder::new(ZlibEncoder::new(dst, Compression::default()), header);
     value.serialize(&mut encoder)
 }
 


### PR DESCRIPTION
This will allow `hematite_nbt` to finally be compiled to wasm target.