### PR TITLE
Fix performance regression in array serialization

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -198,7 +198,7 @@ macro_rules! array_serializer {
 
         let mut seq = $serializer.serialize_tuple_struct(magic, length)?;
         for _i in 0..length {
-            seq.serialize_field(iter.next().ok_or(SerError::custom(error))?.borrow())?;
+            seq.serialize_field(iter.next().ok_or_else(|| SerError::custom(error))?.borrow())?;
         }
 
         if iter.next().is_some() {


### PR DESCRIPTION
I noticed poor performance when serializing arrays, and profiling revealed that `i8_array`, `i32_array`, etc. were allocating a string for each element. Removing the allocation increases performance by an order of magnitude.