### PR TITLE
add `nbt::from_slice` and zero copy support for strings

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,4 +1,7 @@
-use crate::{raw::Read, Map};
+use crate::{
+    raw::{Read, SliceRead},
+    Map,
+};
 use std::fmt;
 use std::io;
 use std::ops::Index;
@@ -16,7 +19,7 @@ use value::Value;
 ///
 /// This is essentially a map of names to `Value`s, with an optional top-level
 /// name of its own. It can be created in a similar way to a `HashMap`, or read
-/// from an `io::Read` source, and its binary representation can be written to
+/// from an `io::Read` or `&[u8]` source, and its binary representation can be written to
 /// an `io::Write` destination.
 ///
 /// These read and write methods support both uncompressed and compressed
@@ -61,8 +64,8 @@ impl Blob {
         }
     }
 
-    /// Extracts an `Blob` object from an `io::Read` source.
-    pub fn from_reader<'de, R>(src: &mut R) -> Result<Blob>
+    /// Extracts an `Blob` object from an `Read` source.
+    fn from_trait<'de, R>(src: &mut R) -> Result<Blob>
     where
         R: Read<'de>,
     {
@@ -73,7 +76,7 @@ impl Blob {
         if tag != 0x0a {
             return Err(Error::NoRootCompound);
         }
-        let content = Value::from_reader(tag, src)?;
+        let content = Value::from_trait(tag, src)?;
         match content {
             Value::Compound(map) => Ok(Blob {
                 title: title.into_owned(),
@@ -81,6 +84,24 @@ impl Blob {
             }),
             _ => Err(Error::NoRootCompound),
         }
+    }
+
+    /// Extracts an `Blob` object from an `&[u8]` source.
+    pub fn from_slice<'de, R>(src: &'de [u8]) -> Result<(&'de [u8], Blob)>
+    where
+        R: Read<'de>,
+    {
+        let mut slice_read = SliceRead::new(src);
+        let res = Self::from_trait(&mut slice_read)?;
+        Ok((slice_read.get_inner(), res))
+    }
+
+    /// Extracts an `Blob` object from an `io::Read` source.
+    pub fn from_reader<R>(src: &mut R) -> Result<Blob>
+    where
+        R: io::Read,
+    {
+        Self::from_trait(src)
     }
 
     /// Extracts an `Blob` object from an `io::Read` source that is

--- a/src/de.rs
+++ b/src/de.rs
@@ -72,7 +72,7 @@ pub struct Decoder<R> {
 }
 
 impl<R> Decoder<R> {
-    /// Create an NBT Decoder from a given `io::Read` source.
+    /// Create an NBT Decoder from a given source.
     pub fn new(src: R) -> Self {
         Decoder {
             reader: src,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use std::collections::HashMap as Map;
 
 #[cfg(feature = "serde")]
 #[doc(inline)]
-pub use de::{from_gzip_reader, from_reader, from_zlib_reader};
+pub use de::{from_gzip_reader, from_reader, from_slice, from_zlib_reader};
 #[cfg(feature = "serde")]
 #[doc(inline)]
 pub use ser::{i32_array, i64_array, i8_array};

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,6 +1,10 @@
 //! Primitive functions for serializing and deserializing NBT data.
 
-use std::io;
+use std::{
+    borrow::Cow,
+    io::{self, Cursor},
+    usize,
+};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use cesu8::{from_java_cesu8, to_java_cesu8};
@@ -112,136 +116,292 @@ where
     dst.write_all(&encoded).map_err(From::from)
 }
 
-/// Extracts the next header (tag and name) from an NBT format source.
-///
-/// This function will also return the `TAG_End` byte and an empty name if it
-/// encounters it.
-pub fn emit_next_header<R>(src: &mut R) -> Result<(u8, String)>
-where
-    R: io::Read,
-{
-    let tag = src.read_u8()?;
+pub trait Read<'de> {
+    /// Extracts the next header (tag and name) from an NBT format source.
+    ///
+    /// This function will also return the `TAG_End` byte and an empty name if it
+    /// encounters it.
+    fn emit_next_header<'s>(
+        &mut self,
+        scratch: Option<&'s mut Vec<u8>>,
+    ) -> Result<(u8, Reference<'de, 's, str>)> {
+        let tag = self.read_id()?;
 
-    match tag {
-        0x00 => Ok((tag, "".to_string())),
-        _ => {
-            let name = read_bare_string(src)?;
-            Ok((tag, name))
+        match tag {
+            0x00 => Ok((tag, Reference::Borrowed(""))),
+            _ => {
+                let name = self.read_bare_string(scratch)?;
+                Ok((tag, name))
+            }
+        }
+    }
+
+    fn read_id(&mut self) -> Result<u8>;
+    fn read_length(&mut self) -> Result<i32>;
+    fn read_bare_byte(&mut self) -> Result<i8>;
+    fn read_bare_short(&mut self) -> Result<i16>;
+    fn read_bare_int(&mut self) -> Result<i32>;
+    fn read_bare_long(&mut self) -> Result<i64>;
+    fn read_bare_float(&mut self) -> Result<f32>;
+    fn read_bare_double(&mut self) -> Result<f64>;
+    fn read_bare_byte_array(&mut self) -> Result<Vec<i8>>;
+    fn read_bare_int_array(&mut self) -> Result<Vec<i32>>;
+    fn read_bare_long_array(&mut self) -> Result<Vec<i64>>;
+    fn read_bare_string<'s>(
+        &mut self,
+        scratch: Option<&'s mut Vec<u8>>,
+    ) -> Result<Reference<'de, 's, str>>;
+}
+
+pub enum Reference<'b, 'c, T>
+where
+    T: ?Sized + ToOwned + 'static,
+{
+    Borrowed(&'b T),
+    Copied(&'c T),
+    Owned(T::Owned),
+}
+
+impl<T> Reference<'_, '_, T>
+where
+    T: ?Sized + ToOwned + 'static,
+{
+    pub fn into_owned(self) -> T::Owned {
+        match self {
+            Reference::Borrowed(r) => r.to_owned(),
+            Reference::Copied(r) => r.to_owned(),
+            Reference::Owned(o) => o,
         }
     }
 }
 
-#[inline]
-pub fn read_bare_byte<R>(src: &mut R) -> Result<i8>
-where
-    R: io::Read,
-{
-    src.read_i8().map_err(From::from)
+pub struct SliceRead<'de> {
+    cursor: Cursor<&'de [u8]>,
 }
 
-#[inline]
-pub fn read_bare_short<R>(src: &mut R) -> Result<i16>
-where
-    R: io::Read,
-{
-    src.read_i16::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_int<R>(src: &mut R) -> Result<i32>
-where
-    R: io::Read,
-{
-    src.read_i32::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_long<R>(src: &mut R) -> Result<i64>
-where
-    R: io::Read,
-{
-    src.read_i64::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_float<R>(src: &mut R) -> Result<f32>
-where
-    R: io::Read,
-{
-    src.read_f32::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_double<R>(src: &mut R) -> Result<f64>
-where
-    R: io::Read,
-{
-    src.read_f64::<BigEndian>().map_err(From::from)
-}
-
-#[inline]
-pub fn read_bare_byte_array<R>(src: &mut R) -> Result<Vec<i8>>
-where
-    R: io::Read,
-{
-    // FIXME: Is there a way to return [u8; len]?
-    let len = src.read_i32::<BigEndian>()? as usize;
-    let mut buf = Vec::with_capacity(len);
-    // FIXME: Test performance vs transmute.
-    for _ in 0..len {
-        buf.push(src.read_i8()?);
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_int_array<R>(src: &mut R) -> Result<Vec<i32>>
-where
-    R: io::Read,
-{
-    // FIXME: Is there a way to return [i32; len]?
-    let len = src.read_i32::<BigEndian>()? as usize;
-    let mut buf = Vec::with_capacity(len);
-    // FIXME: Test performance vs transmute.
-    for _ in 0..len {
-        buf.push(src.read_i32::<BigEndian>()?);
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_long_array<R>(src: &mut R) -> Result<Vec<i64>>
-where
-    R: io::Read,
-{
-    let len = src.read_i32::<BigEndian>()? as usize;
-    let mut buf = Vec::with_capacity(len);
-    for _ in 0..len {
-        buf.push(src.read_i64::<BigEndian>()?);
-    }
-    Ok(buf)
-}
-
-#[inline]
-pub fn read_bare_string<R>(src: &mut R) -> Result<String>
-where
-    R: io::Read,
-{
-    let len = src.read_u16::<BigEndian>()? as usize;
-
-    if len == 0 {
-        return Ok("".to_string());
-    }
-
-    let mut bytes = vec![0; len];
-    let mut n_read = 0usize;
-    while n_read < bytes.len() {
-        match src.read(&mut bytes[n_read..])? {
-            0 => return Err(Error::IncompleteNbtValue),
-            n => n_read += n,
+impl<'de> SliceRead<'de> {
+    pub fn new(data: &'de [u8]) -> Self {
+        Self {
+            cursor: Cursor::new(data),
         }
     }
 
-    let decoded = from_java_cesu8(&bytes)?;
-    Ok(decoded.into_owned())
+    pub fn get_inner(&self) -> &'de [u8] {
+        &self.cursor.get_ref()[self.cursor.position() as usize..]
+    }
+}
+
+impl<'de> Read<'de> for SliceRead<'de> {
+    #[inline]
+    fn read_id(&mut self) -> Result<u8> {
+        self.cursor.read_u8().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_length(&mut self) -> Result<i32> {
+        self.cursor.read_i32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_byte(&mut self) -> Result<i8> {
+        self.cursor.read_i8().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_short(&mut self) -> Result<i16> {
+        self.cursor.read_i16::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_int(&mut self) -> Result<i32> {
+        self.cursor.read_i32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_long(&mut self) -> Result<i64> {
+        self.cursor.read_i64::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_float(&mut self) -> Result<f32> {
+        self.cursor.read_f32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_double(&mut self) -> Result<f64> {
+        self.cursor.read_f64::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_byte_array<'s>(&mut self) -> Result<Vec<i8>> {
+        // FIXME: Is there a way to return [u8; len]?
+        let len = self.cursor.read_i32::<BigEndian>()? as usize;
+        let pos = self.cursor.position();
+        let buf = &self.cursor.get_ref()[pos as usize..];
+        if buf.len() < len {
+            return Err(Error::IncompleteNbtValue);
+        }
+        self.cursor.set_position(pos + len as u64);
+        let buf = &buf[..len];
+
+        let b = unsafe { std::slice::from_raw_parts(buf.as_ptr().cast(), len) };
+        Ok(b.to_vec())
+    }
+
+    #[inline]
+    fn read_bare_int_array(&mut self) -> Result<Vec<i32>> {
+        // FIXME: Is there a way to return [i32; len]?
+        let len = self.cursor.read_i32::<BigEndian>()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        // FIXME: Test performance vs transmute.
+        for _ in 0..len {
+            buf.push(self.cursor.read_i32::<BigEndian>()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    fn read_bare_long_array(&mut self) -> Result<Vec<i64>> {
+        let len = self.cursor.read_i32::<BigEndian>()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        for _ in 0..len {
+            buf.push(self.cursor.read_i64::<BigEndian>()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    fn read_bare_string<'s>(
+        &mut self,
+        _scratch: Option<&'s mut Vec<u8>>,
+    ) -> Result<Reference<'de, 's, str>> {
+        let len = self.cursor.read_u16::<BigEndian>()? as usize;
+
+        if len == 0 {
+            return Ok(Reference::Borrowed(""));
+        }
+
+        let pos = self.cursor.position();
+        let bytes = &self.cursor.get_ref()[pos as usize..];
+        if bytes.len() < len {
+            return Err(Error::IncompleteNbtValue);
+        }
+        let bytes = &bytes[..len];
+        self.cursor.set_position(pos + len as u64);
+
+        let decoded = from_java_cesu8(bytes)?;
+        let reference = match decoded {
+            Cow::Borrowed(s) => Reference::Borrowed(s),
+            Cow::Owned(s) => Reference::Owned(s),
+        };
+        Ok(reference)
+    }
+}
+
+impl<'de, T: io::Read> Read<'de> for T {
+    #[inline]
+    fn read_id(&mut self) -> Result<u8> {
+        self.read_u8().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_length(&mut self) -> Result<i32> {
+        self.read_i32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_byte(&mut self) -> Result<i8> {
+        self.read_i8().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_short(&mut self) -> Result<i16> {
+        self.read_i16::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_int(&mut self) -> Result<i32> {
+        self.read_i32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_long(&mut self) -> Result<i64> {
+        self.read_i64::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_float(&mut self) -> Result<f32> {
+        self.read_f32::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_double(&mut self) -> Result<f64> {
+        self.read_f64::<BigEndian>().map_err(From::from)
+    }
+
+    #[inline]
+    fn read_bare_byte_array(&mut self) -> Result<Vec<i8>> {
+        // FIXME: Is there a way to return [u8; len]?
+        let len = self.read_i32::<BigEndian>()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        // FIXME: Test performance vs transmute.
+        for _ in 0..len {
+            buf.push(self.read_i8()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    fn read_bare_int_array(&mut self) -> Result<Vec<i32>> {
+        // FIXME: Is there a way to return [i32; len]?
+        let len = self.read_i32::<BigEndian>()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        // FIXME: Test performance vs transmute.
+        for _ in 0..len {
+            buf.push(self.read_i32::<BigEndian>()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    fn read_bare_long_array(&mut self) -> Result<Vec<i64>> {
+        let len = self.read_i32::<BigEndian>()? as usize;
+        let mut buf = Vec::with_capacity(len);
+        for _ in 0..len {
+            buf.push(self.read_i64::<BigEndian>()?);
+        }
+        Ok(buf)
+    }
+
+    #[inline]
+    fn read_bare_string<'s>(
+        &mut self,
+        scratch: Option<&'s mut Vec<u8>>,
+    ) -> Result<Reference<'de, 's, str>> {
+        let len = self.read_u16::<BigEndian>()? as usize;
+
+        if len == 0 {
+            return Ok(Reference::Borrowed(""));
+        }
+
+        if let Some(scratch) = scratch {
+            scratch.resize(len, 0);
+            self.read_exact(scratch)
+                .map_err(|_| Error::IncompleteNbtValue)?;
+
+            let decoded = from_java_cesu8(scratch)?;
+            let reference = match decoded {
+                Cow::Borrowed(s) => Reference::Copied(s),
+                Cow::Owned(s) => Reference::Owned(s),
+            };
+            Ok(reference)
+        } else {
+            let mut buf = vec![0; len];
+            self.read_exact(&mut buf)
+                .map_err(|_| Error::IncompleteNbtValue)?;
+
+            let decoded = from_java_cesu8(&buf)?;
+            Ok(Reference::Owned(decoded.into_owned()))
+        }
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,8 +1,8 @@
-use crate::Map;
+use crate::{raw::Read, Map};
 use std::fmt;
 use std::io;
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use byteorder::{BigEndian, WriteBytesExt};
 
 use error::{Error, Result};
 use raw;
@@ -116,23 +116,23 @@ impl Value {
 
     /// Reads the payload of an `Value` with a given type ID from an
     /// `io::Read` source.
-    pub fn from_reader<R>(id: u8, src: &mut R) -> Result<Value>
+    pub fn from_reader<'de, R>(id: u8, src: &mut R) -> Result<Value>
     where
-        R: io::Read,
+        R: Read<'de>,
     {
         match id {
-            0x01 => Ok(Value::Byte(raw::read_bare_byte(src)?)),
-            0x02 => Ok(Value::Short(raw::read_bare_short(src)?)),
-            0x03 => Ok(Value::Int(raw::read_bare_int(src)?)),
-            0x04 => Ok(Value::Long(raw::read_bare_long(src)?)),
-            0x05 => Ok(Value::Float(raw::read_bare_float(src)?)),
-            0x06 => Ok(Value::Double(raw::read_bare_double(src)?)),
-            0x07 => Ok(Value::ByteArray(raw::read_bare_byte_array(src)?)),
-            0x08 => Ok(Value::String(raw::read_bare_string(src)?)),
+            0x01 => Ok(Value::Byte(src.read_bare_byte()?)),
+            0x02 => Ok(Value::Short(src.read_bare_short()?)),
+            0x03 => Ok(Value::Int(src.read_bare_int()?)),
+            0x04 => Ok(Value::Long(src.read_bare_long()?)),
+            0x05 => Ok(Value::Float(src.read_bare_float()?)),
+            0x06 => Ok(Value::Double(src.read_bare_double()?)),
+            0x07 => Ok(Value::ByteArray(src.read_bare_byte_array()?)),
+            0x08 => Ok(Value::String(src.read_bare_string(None)?.into_owned())),
             0x09 => {
                 // List
-                let id = src.read_u8()?;
-                let len = src.read_i32::<BigEndian>()? as usize;
+                let id = src.read_id()?;
+                let len = src.read_length()? as usize;
                 let mut buf = Vec::with_capacity(len);
                 for _ in 0..len {
                     buf.push(Value::from_reader(id, src)?);
@@ -143,17 +143,17 @@ impl Value {
                 // Compound
                 let mut buf = Map::new();
                 loop {
-                    let (id, name) = raw::emit_next_header(src)?;
+                    let (id, name) = src.emit_next_header(None)?;
                     if id == 0x00 {
                         break;
                     }
                     let tag = Value::from_reader(id, src)?;
-                    buf.insert(name, tag);
+                    buf.insert(name.into_owned(), tag);
                 }
                 Ok(Value::Compound(buf))
             }
-            0x0b => Ok(Value::IntArray(raw::read_bare_int_array(src)?)),
-            0x0c => Ok(Value::LongArray(raw::read_bare_long_array(src)?)),
+            0x0b => Ok(Value::IntArray(src.read_bare_int_array()?)),
+            0x0c => Ok(Value::LongArray(src.read_bare_long_array()?)),
             e => Err(Error::InvalidTypeId(e)),
         }
     }

--- a/tests/serde_basics.rs
+++ b/tests/serde_basics.rs
@@ -22,6 +22,9 @@ where
 
     let read: T = nbt::de::from_reader(bytes).expect("NBT deserialization.");
     assert_eq!(read, nbt);
+
+    let read: T = nbt::de::from_slice(bytes).expect("NBT deserialization.").1;
+    assert_eq!(read, nbt);
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This pr adds `nbt::from_slice` to enable zero copy deserialization for strings. The implementation is inspired by `serde_json` which uses a trait to abstract over multiple sources. 

All of the `read_*` functions in `raw.rs` got moved into a trait. This trait is implemented for `std::io::Read` and `&[u8]`. 

The `read_bare_string` function was modified to also take a scratch buffer and return a borrowed, copied or owned string. In a lot of cases this enables reading a string without allocating. This is useful beyond zero copy as it's also used for identifiers in structs. This optimization is not used for `Value` and `Blob` as they always allocate anyways.

Even though zero support is added `Cow<'de, str>` has to be used because modified utf-8 does always allow zero copy.

Example:
```rust

#[derive(Deserialize)]
#[serde(rename_all = "PascalCase")]
pub struct Section<'a> {
    #[serde(serialize_with = "nbt::i64_array", default)]
    pub block_states: Option<Vec<i64>>,
    #[serde(borrow)]
    pub palette: Option<Vec<Block<'a>>>,
    pub y: i8,
}

#[derive(Deserialize, Hash)]
#[serde(rename_all = "PascalCase")]
pub struct Block<'a> {
    #[serde(borrow)]
    pub name: Cow<'a, str>,
    #[serde(default, borrow)]
    pub properties: Option<BTreeMap<Cow<'a, str>, Cow<'a, str>>>,
}
```

I had some trouble getting reliable results from the benchmarks, but there usually were only small regressions of up to 5% and improvements of  up to 10-20%. (The benchmarks were not modified, I suspect all the speed up was from prevent allocations for identifiers in structs). I got varying but mostly positive results in my personal project for parsing anvil chunks with zero copy.