### PR TITLE
Fix array value serialization

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -23,7 +23,9 @@ pub enum Value {
     String(String),
     List(Vec<Value>),
     Compound(Map<String, Value>),
+    #[cfg_attr(feature = "serde", serde(serialize_with = "crate::i32_array"))]
     IntArray(Vec<i32>),
+    #[cfg_attr(feature = "serde", serde(serialize_with = "crate::i64_array"))]
     LongArray(Vec<i64>),
 }
 

--- a/tests/serde_basics.rs
+++ b/tests/serde_basics.rs
@@ -567,3 +567,34 @@ fn roundtrip_hashmap() {
 
     assert_roundtrip_eq(nbt, &bytes, None);
 }
+
+#[test]
+fn ser_blob_array() {
+    let mut blob = nbt::Blob::new();
+    blob.insert("larr", nbt::Value::LongArray(vec![456, 123])).unwrap();
+    blob.insert("iarr", nbt::Value::IntArray(vec![123, 456])).unwrap();
+
+    #[rustfmt::skip]
+    let bytes = vec![
+        0x0a,
+            0x00, 0x00,
+            0x0c,
+                0x00, 0x04,
+                0x6c, 0x61, 0x72, 0x72,
+                0x00, 0x00, 0x00, 0x02,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xc8,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7b,
+            0x0b,
+                0x00, 0x04,
+                0x69, 0x61, 0x72, 0x72,
+                0x00, 0x00, 0x00, 0x02,
+                0x00, 0x00, 0x00, 0x7b,
+                0x00, 0x00, 0x01, 0xc8,
+        0x00
+    ];
+
+    let mut dst = Vec::with_capacity(bytes.len());
+
+    nbt::ser::to_writer(&mut dst, &blob, None).expect("NBT serialization.");
+    assert_eq!(bytes, &dst[..]);
+}


### PR DESCRIPTION
Serializing a `Blob` containing a `Value::IntArray` or `Value::LongArray` would instead serialize them as lists. 