### PR TITLE
Allow deserializing empty compound tags in deserialize_any

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -73,9 +73,7 @@ impl<'de: 'a, 'a, R: io::Read> de::Deserializer<'de> for &'a mut Decoder<R> {
     where
         V: de::Visitor<'de>,
     {
-        // The decoder cannot deserialize types by default. It can only handle
-        // maps and structs.
-        Err(Error::NoRootCompound)
+        self.deserialize_map(visitor)
     }
 
     fn deserialize_struct<V>(

--- a/src/de.rs
+++ b/src/de.rs
@@ -69,7 +69,7 @@ where
 impl<'de: 'a, 'a, R: io::Read> de::Deserializer<'de> for &'a mut Decoder<R> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {


### PR DESCRIPTION
Now it returns an error in `deserialize_map` if the tag is not `0x0A` instead of just returning an error in deserialize_any.
```rs
let empty = nbt::Value::Compound(HashMap::new());
let mut serialized = Vec::new();
nbt::to_writer(&mut serialized, &empty, None).unwrap();
assert_eq!(serialized, vec![0x0A, 0x00, 0x00, 0x00]);
let should_work: nbt::Value = nbt::from_reader(Cursor::new(serialized)).unwrap(); // Error::NoRootCompound
```