### PR TITLE
Feature/allow quick exit

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -152,6 +152,7 @@ impl<'de: 'a, 'a, R: io::Read + 'a> de::MapAccess<'de> for MapDecoder<'a, R> {
         K: de::DeserializeSeed<'de>,
     {
         if matches!(self.tag, Some(0x00)) {
+            println!("Reading quick exit header.");
             // we exit early here - we know that the map contains nothing from a 0x00 headed object
             return Ok(None);
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -152,7 +152,6 @@ impl<'de: 'a, 'a, R: io::Read + 'a> de::MapAccess<'de> for MapDecoder<'a, R> {
         K: de::DeserializeSeed<'de>,
     {
         if matches!(self.tag, Some(0x00)) {
-            println!("Reading quick exit header.");
             // we exit early here - we know that the map contains nothing from a 0x00 headed object
             return Ok(None);
         }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -107,10 +107,8 @@ pub fn write_bare_string<W>(dst: &mut W, value: &str) -> Result<()>
 where
     W: io::Write,
 {
-    println!("Writing string: {}", value);
     let encoded = to_java_cesu8(value);
     dst.write_u16::<BigEndian>(encoded.len() as u16)?;
-    println!("Writing {} as len", encoded.len());
     dst.write_all(&encoded).map_err(From::from)
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -107,8 +107,10 @@ pub fn write_bare_string<W>(dst: &mut W, value: &str) -> Result<()>
 where
     W: io::Write,
 {
+    println!("Writing string: {}", value);
     let encoded = to_java_cesu8(value);
     dst.write_u16::<BigEndian>(encoded.len() as u16)?;
+    println!("Writing {} as len", encoded.len());
     dst.write_all(&encoded).map_err(From::from)
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -269,7 +269,12 @@ where
 
     /// Serialize maps as `Tag_Compound` data.
     #[inline]
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        if matches!(len, Some(0)) {
+            self.write_header(0, None)?;
+            return Ok(Compound::from_outer(self));
+        }
+
         let header = self.header; // Circumvent strange borrowing errors.
         self.write_header(0x0a, header)?;
         Ok(Compound::from_outer(self))
@@ -277,7 +282,12 @@ where
 
     /// Serialize structs as `Tag_Compound` data.
     #[inline]
-    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        if len == 0 {
+            self.write_header(0, None)?;
+            return Ok(Compound::from_outer(self));
+        }
+
         let header = self.header; // Circumvent strange borrowing errors.
         self.write_header(0x0a, header)?;
         Ok(Compound::from_outer(self))

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -271,6 +271,7 @@ where
     #[inline]
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         if matches!(len, Some(0)) {
+            println!("Writing quick exit header.");
             self.write_header(0, None)?;
             return Ok(Compound::from_outer(self));
         }
@@ -284,6 +285,7 @@ where
     #[inline]
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
         if len == 0 {
+            println!("Writing quick exit header.");
             self.write_header(0, None)?;
             return Ok(Compound::from_outer(self));
         }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -20,6 +20,7 @@ where
     W: ?Sized + io::Write,
     T: ?Sized + ser::Serialize,
 {
+    println!("To writer call, let's follow the logic here.");
     let mut encoder = Encoder::new(dst, header);
     value.serialize(&mut encoder)
 }
@@ -69,6 +70,7 @@ where
     /// Write the NBT tag and an optional header to the underlying writer.
     #[inline]
     fn write_header(&mut self, tag: i8, header: Option<&str>) -> Result<()> {
+        println!("Writing bare byte {}", tag);
         raw::write_bare_byte(&mut self.writer, tag)?;
         match header {
             None => raw::write_bare_short(&mut self.writer, 0).map_err(From::from),
@@ -283,7 +285,9 @@ where
 
     /// Serialize structs as `Tag_Compound` data.
     #[inline]
-    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        println!("Serializing struct {} with length {}", name, len);
+
         if len == 0 {
             println!("Writing quick exit header.");
             self.write_header(0, None)?;
@@ -291,6 +295,7 @@ where
         }
 
         let header = self.header; // Circumvent strange borrowing errors.
+        println!("Writing 0x0a header...");
         self.write_header(0x0a, header)?;
         Ok(Compound::from_outer(self))
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -20,7 +20,6 @@ where
     W: ?Sized + io::Write,
     T: ?Sized + ser::Serialize,
 {
-    println!("To writer call, let's follow the logic here.");
     let mut encoder = Encoder::new(dst, header);
     value.serialize(&mut encoder)
 }
@@ -70,7 +69,6 @@ where
     /// Write the NBT tag and an optional header to the underlying writer.
     #[inline]
     fn write_header(&mut self, tag: i8, header: Option<&str>) -> Result<()> {
-        println!("Writing bare byte {}", tag);
         raw::write_bare_byte(&mut self.writer, tag)?;
         match header {
             None => raw::write_bare_short(&mut self.writer, 0).map_err(From::from),
@@ -273,7 +271,6 @@ where
     #[inline]
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         if matches!(len, Some(0)) {
-            println!("Writing quick exit header.");
             self.write_header(0, None)?;
             return Ok(Compound::from_outer(self));
         }
@@ -285,17 +282,13 @@ where
 
     /// Serialize structs as `Tag_Compound` data.
     #[inline]
-    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        println!("Serializing struct {} with length {}", name, len);
-
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
         if len == 0 {
-            println!("Writing quick exit header.");
             self.write_header(0, None)?;
             return Ok(Compound::from_outer(self));
         }
 
         let header = self.header; // Circumvent strange borrowing errors.
-        println!("Writing 0x0a header...");
         self.write_header(0x0a, header)?;
         Ok(Compound::from_outer(self))
     }


### PR DESCRIPTION
In the minecraft net source code there is a "quick exit" during `0x00` reads for base NBT objects.

```java
    private static Tag readUnnamedTag(DataInput dataInput, int n, NbtAccounter nbtAccounter) throws IOException {
        byte by = dataInput.readByte();
        if (by == 0) {
            return EndTag.INSTANCE;
        }
        StringTag.skipString(dataInput);
        try {
            return TagTypes.getType(by).load(dataInput, n, nbtAccounter);
        // omitted
    }
```

Here we see that when the tag is `0x00` it won't read a header - and instead exit early with a "blank object", we should replicate this behavior when we have an object with nothing to serialize. This is especially helpful for "empty" nbt tags.